### PR TITLE
新增HasKey和HasValue方法，用来判断键或值是否存在。

### DIFF
--- a/ini.go
+++ b/ini.go
@@ -620,16 +620,8 @@ func (s *Section) GetKey(name string) (*Key, error) {
 
 // HasKey returns true if section contains a key with given name
 func (s *Section) Haskey(name string) bool {
-	if s.f.BlockMode {
-		s.f.lock.RLock()
-		defer s.f.lock.RUnlock()
-	}
-
 	key, _ := s.GetKey(name)
-	if key == nil {
-		return false
-	}
-	return true
+	return key != nil
 }
 
 // HasKey returns true if section contains a value with given value

--- a/ini.go
+++ b/ini.go
@@ -618,6 +618,54 @@ func (s *Section) GetKey(name string) (*Key, error) {
 	return key, nil
 }
 
+// HasKey return boolean value to determine whether given name is exist
+func (s *Section) Haskey(name string) bool {
+	if s.f.BlockMode {
+		s.f.lock.RLock()
+		defer s.f.lock.RUnlock()
+	}
+
+	keys := s.keyList
+	for _, v := range keys {
+		if name == v {
+			return true
+		}
+	}
+
+	// Check if it is a child-section.
+	sname := s.name
+	for {
+		if i := strings.LastIndex(sname, "."); i > -1 {
+			sname = sname[:i]
+			sec, err := s.f.GetSection(sname)
+			if err != nil {
+				continue
+			}
+			return sec.Haskey(name)
+		} else {
+			break
+		}
+	}
+
+	return false
+}
+
+// HasValue return boolean value to determine whether given value is exist
+func (s *Section) HasValue(value string) bool {
+	if s.f.BlockMode {
+		s.f.lock.RLock()
+		defer s.f.lock.RUnlock()
+	}
+
+	keys := s.KeysHash()
+	for _, v := range keys {
+		if value == v {
+			return true
+		}
+	}
+	return false
+}
+
 // Key assumes named Key exists in section and returns a zero-value when not.
 func (s *Section) Key(name string) *Key {
 	key, err := s.GetKey(name)

--- a/ini.go
+++ b/ini.go
@@ -625,29 +625,11 @@ func (s *Section) Haskey(name string) bool {
 		defer s.f.lock.RUnlock()
 	}
 
-	keys := s.keyList
-	for _, v := range keys {
-		if name == v {
-			return true
-		}
+	key, _ := s.GetKey(name)
+	if key == nil {
+		return false
 	}
-
-	// Check if it is a child-section.
-	sname := s.name
-	for {
-		if i := strings.LastIndex(sname, "."); i > -1 {
-			sname = sname[:i]
-			sec, err := s.f.GetSection(sname)
-			if err != nil {
-				continue
-			}
-			return sec.Haskey(name)
-		} else {
-			break
-		}
-	}
-
-	return false
+	return true
 }
 
 // HasKey returns true if section contains a value with given value

--- a/ini.go
+++ b/ini.go
@@ -618,7 +618,7 @@ func (s *Section) GetKey(name string) (*Key, error) {
 	return key, nil
 }
 
-// HasKey return boolean value to determine whether given name is exist
+// HasKey returns true if section contains a key with given name
 func (s *Section) Haskey(name string) bool {
 	if s.f.BlockMode {
 		s.f.lock.RLock()
@@ -650,16 +650,15 @@ func (s *Section) Haskey(name string) bool {
 	return false
 }
 
-// HasValue return boolean value to determine whether given value is exist
+// HasKey returns true if section contains a value with given value
 func (s *Section) HasValue(value string) bool {
 	if s.f.BlockMode {
 		s.f.lock.RLock()
 		defer s.f.lock.RUnlock()
 	}
 
-	keys := s.KeysHash()
-	for _, v := range keys {
-		if value == v {
+	for _, v := range s.keys {
+		if value == v.value {
 			return true
 		}
 	}

--- a/ini_test.go
+++ b/ini_test.go
@@ -392,6 +392,24 @@ func Test_Values(t *testing.T) {
 			So(err, ShouldNotBeNil)
 		})
 
+		Convey("Has Key", func() {
+			sec := cfg.Section("package.sub")
+			haskey1 := sec.Haskey("UNUSED_KEY")
+			haskey2 := sec.Haskey("CLONE_URL")
+			haskey3 := sec.Haskey("CLONE_URL_NO")
+			So(haskey1, ShouldBeTrue)
+			So(haskey2, ShouldBeTrue)
+			So(haskey3, ShouldBeFalse)
+		})
+
+		Convey("Has Value", func() {
+			sec := cfg.Section("author")
+			hasvalue1 := sec.HasValue("Unknwon")
+			hasvalue2 := sec.HasValue("doc")
+			So(hasvalue1, ShouldBeTrue)
+			So(hasvalue2, ShouldBeFalse)
+		})
+
 		Convey("Get section strings", func() {
 			So(strings.Join(cfg.SectionStrings(), ","), ShouldEqual, "DEFAULT,author,package,package.sub,features,types,array,note,advance")
 		})


### PR DESCRIPTION
增加HasValue的目的是我在使用Peach的时候，toc.ini都是自增键值，所以只用到Value，而且每个分区下的值应该是唯一的，所以如果用程序添加一个文章那么需要判断是否存在这个值。HasValue没有判断子分区是因为我觉得不同子分区内可以有相同的值。