### PR TITLE
Make method name Section.HasKey match documentation.

### DIFF
--- a/ini.go
+++ b/ini.go
@@ -629,7 +629,7 @@ func (s *Section) Haskey(name string) bool {
 	return s.HasKey(name)
 }
 
-// HasKey returns true if section contains given raw value.
+// HasValue returns true if section contains given raw value.
 func (s *Section) HasValue(value string) bool {
 	if s.f.BlockMode {
 		s.f.lock.RLock()

--- a/ini.go
+++ b/ini.go
@@ -619,9 +619,14 @@ func (s *Section) GetKey(name string) (*Key, error) {
 }
 
 // HasKey returns true if section contains a key with given name.
-func (s *Section) Haskey(name string) bool {
+func (s *Section) HasKey(name string) bool {
 	key, _ := s.GetKey(name)
 	return key != nil
+}
+
+// Haskey is a backwards-compatible name for HasKey.
+func (s *Section) Haskey(name string) bool {
+	return s.HasKey(name)
 }
 
 // HasKey returns true if section contains given raw value.

--- a/ini_test.go
+++ b/ini_test.go
@@ -393,11 +393,21 @@ func Test_Values(t *testing.T) {
 			So(err, ShouldNotBeNil)
 		})
 
-		Convey("Has Key", func() {
+		Convey("Has Key (backwards compatible)", func() {
 			sec := cfg.Section("package.sub")
 			haskey1 := sec.Haskey("UNUSED_KEY")
 			haskey2 := sec.Haskey("CLONE_URL")
 			haskey3 := sec.Haskey("CLONE_URL_NO")
+			So(haskey1, ShouldBeTrue)
+			So(haskey2, ShouldBeTrue)
+			So(haskey3, ShouldBeFalse)
+		})
+
+		Convey("Has Key", func() {
+			sec := cfg.Section("package.sub")
+			haskey1 := sec.HasKey("UNUSED_KEY")
+			haskey2 := sec.HasKey("CLONE_URL")
+			haskey3 := sec.HasKey("CLONE_URL_NO")
 			So(haskey1, ShouldBeTrue)
 			So(haskey2, ShouldBeTrue)
 			So(haskey3, ShouldBeFalse)


### PR DESCRIPTION
This commit changes `Section.Haskey` to `Section.HasKey` (notice the capitalization on the k), which is what the documentation states (and which reflects the naming convention for this library). There is also a very minor documentation fix for `Section.HasValue`.