### PR TITLE
Add `y`/`n` as options for BOOL values

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ To get value with types:
 
 ```go
 // For boolean values:
-// true when value is: 1, t, T, TRUE, true, True, YES, yes, Yes, ON, on, On
-// false when value is: 0, f, F, FALSE, false, False, NO, no, No, OFF, off, Off
+// true when value is: 1, t, T, TRUE, true, True, YES, yes, Yes, y, ON, on, On
+// false when value is: 0, f, F, FALSE, false, False, NO, no, No, n, OFF, off, Off
 v, err = cfg.Section("").Key("BOOL").Bool()
 v, err = cfg.Section("").Key("FLOAT64").Float64()
 v, err = cfg.Section("").Key("INT").Int()

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -148,8 +148,8 @@ yes := cfg.Section("").HasValue("test value")
 
 ```go
 // 布尔值的规则：
-// true 当值为：1, t, T, TRUE, true, True, YES, yes, Yes, ON, on, On
-// false 当值为：0, f, F, FALSE, false, False, NO, no, No, OFF, off, Off
+// true 当值为：1, t, T, TRUE, true, True, YES, yes, Yes, y, ON, on, On
+// false 当值为：0, f, F, FALSE, false, False, NO, no, No, n, OFF, off, Off
 v, err = cfg.Section("").Key("BOOL").Bool()
 v, err = cfg.Section("").Key("FLOAT64").Float64()
 v, err = cfg.Section("").Key("INT").Int()

--- a/ini.go
+++ b/ini.go
@@ -163,14 +163,14 @@ func (k *Key) Validate(fn func(string) string) string {
 
 // parseBool returns the boolean value represented by the string.
 //
-// It accepts 1, t, T, TRUE, true, True, YES, yes, Yes, ON, on, On,
-// 0, f, F, FALSE, false, False, NO, no, No, OFF, off, Off.
+// It accepts 1, t, T, TRUE, true, True, YES, yes, Yes, y, ON, on, On,
+// 0, f, F, FALSE, false, False, NO, no, No, n, OFF, off, Off.
 // Any other value returns an error.
 func parseBool(str string) (value bool, err error) {
 	switch str {
-	case "1", "t", "T", "true", "TRUE", "True", "YES", "yes", "Yes", "ON", "on", "On":
+	case "1", "t", "T", "true", "TRUE", "True", "YES", "yes", "Yes", "y", "ON", "on", "On":
 		return true, nil
-	case "0", "f", "F", "false", "FALSE", "False", "NO", "no", "No", "OFF", "off", "Off":
+	case "0", "f", "F", "false", "FALSE", "False", "NO", "no", "No", "n", "OFF", "off", "Off":
 		return false, nil
 	}
 	return false, fmt.Errorf("parsing \"%s\": invalid syntax", str)


### PR DESCRIPTION
`y`/`n` are also used as boolean values sometimes, extending
the library to infer these values for parseBool as well.

Tested manually through editing BOOL/BOOL_FALSE in ini_test.go.

cc: @Unknwon 
