### PR TITLE
Exclude not parsed values from lists.

### DIFF
--- a/ini.go
+++ b/ini.go
@@ -535,6 +535,88 @@ func (k *Key) Times(delim string) []time.Time {
 	return k.TimesFormat(time.RFC3339, delim)
 }
 
+// ValidFloat64s returns list of float64 divided by given delimiter. If some value is not float, then
+// it will not be included to result list.
+func (k *Key) ValidFloat64s(delim string) []float64 {
+	strs := k.Strings(delim)
+	vals := make([]float64, 0, len(strs))
+	for i := range strs {
+		if val, err := strconv.ParseFloat(strs[i], 64); err == nil {
+			vals = append(vals, val)
+		}
+	}
+	return vals
+}
+
+// ValidInts returns list of int divided by given delimiter. If some value is not integer, then it will
+// not be included to result list.
+func (k *Key) ValidInts(delim string) []int {
+	strs := k.Strings(delim)
+	vals := make([]int, 0, len(strs))
+	for i := range strs {
+		if val, err := strconv.Atoi(strs[i]); err == nil {
+			vals = append(vals, val)
+		}
+	}
+	return vals
+}
+
+// ValidInt64s returns list of int64 divided by given delimiter. If some value is not 64-bit integer,
+// then it will not be included to result list.
+func (k *Key) ValidInt64s(delim string) []int64 {
+	strs := k.Strings(delim)
+	vals := make([]int64, 0, len(strs))
+	for i := range strs {
+		if val, err := strconv.ParseInt(strs[i], 10, 64); err == nil {
+			vals = append(vals, val)
+		}
+	}
+	return vals
+}
+
+// ValidUints returns list of uint divided by given delimiter. If some value is not unsigned integer,
+// then it will not be included to result list.
+func (k *Key) ValidUints(delim string) []uint {
+	strs := k.Strings(delim)
+	vals := make([]uint, 0, len(strs))
+	for i := range strs {
+		if val, err := strconv.ParseUint(strs[i], 10, 0); err == nil {
+			vals = append(vals, uint(val))
+		}
+	}
+	return vals
+}
+
+// ValidUint64s returns list of uint64 divided by given delimiter. If some value is not 64-bit unsigned
+// integer, then it will not be included to result list.
+func (k *Key) ValidUint64s(delim string) []uint64 {
+	strs := k.Strings(delim)
+	vals := make([]uint64, 0, len(strs))
+	for i := range strs {
+		if val, err := strconv.ParseUint(strs[i], 10, 64); err == nil {
+			vals = append(vals, val)
+		}
+	}
+	return vals
+}
+
+// ValidTimesFormat parses with given format and returns list of time.Time divided by given delimiter.
+func (k *Key) ValidTimesFormat(format, delim string) []time.Time {
+	strs := k.Strings(delim)
+	vals := make([]time.Time, 0, len(strs))
+	for i := range strs {
+		if val, err := time.Parse(format, strs[i]); err == nil {
+			vals = append(vals, val)
+		}
+	}
+	return vals
+}
+
+// ValidTimes parses with RFC3339 format and returns list of time.Time divided by given delimiter.
+func (k *Key) ValidTimes(delim string) []time.Time {
+	return k.ValidTimesFormat(time.RFC3339, delim)
+}
+
 // SetValue changes key value.
 func (k *Key) SetValue(v string) {
 	if k.s.f.BlockMode {

--- a/ini.go
+++ b/ini.go
@@ -467,67 +467,53 @@ func (k *Key) Strings(delim string) []string {
 	return vals
 }
 
-// Float64s returns list of float64 divided by given delimiter. If some value is not float, then
-// it will not be included to result list.
+// Float64s returns list of float64 divided by given delimiter.
 func (k *Key) Float64s(delim string) []float64 {
 	strs := k.Strings(delim)
-	vals := make([]float64, 0, len(strs))
+	vals := make([]float64, len(strs))
 	for i := range strs {
-		if val, err := strconv.ParseFloat(strs[i], 64); err == nil {
-			vals = append(vals, val)
-		}
+		vals[i], _ = strconv.ParseFloat(strs[i], 64)
 	}
 	return vals
 }
 
-// Ints returns list of int divided by given delimiter. If some value is not integer, then it will
-// not be included to result list.
+// Ints returns list of int divided by given delimiter.
 func (k *Key) Ints(delim string) []int {
 	strs := k.Strings(delim)
-	vals := make([]int, 0, len(strs))
+	vals := make([]int, len(strs))
 	for i := range strs {
-		if val, err := strconv.Atoi(strs[i]); err == nil {
-			vals = append(vals, val)
-		}
+		vals[i], _ = strconv.Atoi(strs[i])
 	}
 	return vals
 }
 
-// Int64s returns list of int64 divided by given delimiter. If some value is not 64-bit integer,
-// then it will not be included to result list.
+// Int64s returns list of int64 divided by given delimiter.
 func (k *Key) Int64s(delim string) []int64 {
 	strs := k.Strings(delim)
-	vals := make([]int64, 0, len(strs))
+	vals := make([]int64, len(strs))
 	for i := range strs {
-		if val, err := strconv.ParseInt(strs[i], 10, 64); err == nil {
-			vals = append(vals, val)
-		}
+		vals[i], _ = strconv.ParseInt(strs[i], 10, 64)
 	}
 	return vals
 }
 
-// Uints returns list of uint divided by given delimiter. If some value is not unsigned integer,
-// then it will not be included to result list.
+// Uints returns list of uint divided by given delimiter.
 func (k *Key) Uints(delim string) []uint {
 	strs := k.Strings(delim)
-	vals := make([]uint, 0, len(strs))
+	vals := make([]uint, len(strs))
 	for i := range strs {
-		if val, err := strconv.ParseUint(strs[i], 10, 0); err == nil {
-			vals = append(vals, uint(val))
-		}
+		u, _ := strconv.ParseUint(strs[i], 10, 0)
+		vals[i] = uint(u)
 	}
 	return vals
 }
 
-// Uint64s returns list of uint64 divided by given delimiter. If some value is not 64-bit unsigned
-// integer, then it will not be included to result list.
+// Uint64s returns list of uint64 divided by given delimiter.
 func (k *Key) Uint64s(delim string) []uint64 {
 	strs := k.Strings(delim)
-	vals := make([]uint64, 0, len(strs))
+	vals := make([]uint64, len(strs))
 	for i := range strs {
-		if val, err := strconv.ParseUint(strs[i], 10, 64); err == nil {
-			vals = append(vals, val)
-		}
+		vals[i], _ = strconv.ParseUint(strs[i], 10, 64)
 	}
 	return vals
 }
@@ -535,11 +521,9 @@ func (k *Key) Uint64s(delim string) []uint64 {
 // TimesFormat parses with given format and returns list of time.Time divided by given delimiter.
 func (k *Key) TimesFormat(format, delim string) []time.Time {
 	strs := k.Strings(delim)
-	vals := make([]time.Time, 0, len(strs))
+	vals := make([]time.Time, len(strs))
 	for i := range strs {
-		if val, err := time.Parse(format, strs[i]); err == nil {
-			vals = append(vals, val)
-		}
+		vals[i], _ = time.Parse(format, strs[i])
 	}
 	return vals
 }

--- a/ini.go
+++ b/ini.go
@@ -469,63 +469,38 @@ func (k *Key) Strings(delim string) []string {
 
 // Float64s returns list of float64 divided by given delimiter. Any invalid input will be treated as zero value.
 func (k *Key) Float64s(delim string) []float64 {
-	strs := k.Strings(delim)
-	vals := make([]float64, len(strs))
-	for i := range strs {
-		vals[i], _ = strconv.ParseFloat(strs[i], 64)
-	}
+	vals, _ := k.getFloat64s(delim, true, false)
 	return vals
 }
 
 // Ints returns list of int divided by given delimiter. Any invalid input will be treated as zero value.
 func (k *Key) Ints(delim string) []int {
-	strs := k.Strings(delim)
-	vals := make([]int, len(strs))
-	for i := range strs {
-		vals[i], _ = strconv.Atoi(strs[i])
-	}
+	vals, _ := k.getInts(delim, true, false)
 	return vals
 }
 
 // Int64s returns list of int64 divided by given delimiter. Any invalid input will be treated as zero value.
 func (k *Key) Int64s(delim string) []int64 {
-	strs := k.Strings(delim)
-	vals := make([]int64, len(strs))
-	for i := range strs {
-		vals[i], _ = strconv.ParseInt(strs[i], 10, 64)
-	}
+	vals, _ := k.getInt64s(delim, true, false)
 	return vals
 }
 
 // Uints returns list of uint divided by given delimiter. Any invalid input will be treated as zero value.
 func (k *Key) Uints(delim string) []uint {
-	strs := k.Strings(delim)
-	vals := make([]uint, len(strs))
-	for i := range strs {
-		u, _ := strconv.ParseUint(strs[i], 10, 0)
-		vals[i] = uint(u)
-	}
+	vals, _ := k.getUints(delim, true, false)
 	return vals
 }
 
 // Uint64s returns list of uint64 divided by given delimiter. Any invalid input will be treated as zero value.
 func (k *Key) Uint64s(delim string) []uint64 {
-	strs := k.Strings(delim)
-	vals := make([]uint64, len(strs))
-	for i := range strs {
-		vals[i], _ = strconv.ParseUint(strs[i], 10, 64)
-	}
+	vals, _ := k.getUint64s(delim, true, false)
 	return vals
 }
 
 // TimesFormat parses with given format and returns list of time.Time divided by given delimiter.
 // Any invalid input will be treated as zero value (0001-01-01 00:00:00 +0000 UTC).
 func (k *Key) TimesFormat(format, delim string) []time.Time {
-	strs := k.Strings(delim)
-	vals := make([]time.Time, len(strs))
-	for i := range strs {
-		vals[i], _ = time.Parse(format, strs[i])
-	}
+	vals, _ := k.getTimesFormat(format, delim, true, false)
 	return vals
 }
 
@@ -538,83 +513,180 @@ func (k *Key) Times(delim string) []time.Time {
 // ValidFloat64s returns list of float64 divided by given delimiter. If some value is not float, then
 // it will not be included to result list.
 func (k *Key) ValidFloat64s(delim string) []float64 {
-	strs := k.Strings(delim)
-	vals := make([]float64, 0, len(strs))
-	for i := range strs {
-		if val, err := strconv.ParseFloat(strs[i], 64); err == nil {
-			vals = append(vals, val)
-		}
-	}
+	vals, _ := k.getFloat64s(delim, false, false)
 	return vals
 }
 
 // ValidInts returns list of int divided by given delimiter. If some value is not integer, then it will
 // not be included to result list.
 func (k *Key) ValidInts(delim string) []int {
-	strs := k.Strings(delim)
-	vals := make([]int, 0, len(strs))
-	for i := range strs {
-		if val, err := strconv.Atoi(strs[i]); err == nil {
-			vals = append(vals, val)
-		}
-	}
+	vals, _ := k.getInts(delim, false, false)
 	return vals
 }
 
 // ValidInt64s returns list of int64 divided by given delimiter. If some value is not 64-bit integer,
 // then it will not be included to result list.
 func (k *Key) ValidInt64s(delim string) []int64 {
-	strs := k.Strings(delim)
-	vals := make([]int64, 0, len(strs))
-	for i := range strs {
-		if val, err := strconv.ParseInt(strs[i], 10, 64); err == nil {
-			vals = append(vals, val)
-		}
-	}
+	vals, _ := k.getInt64s(delim, false, false)
 	return vals
 }
 
 // ValidUints returns list of uint divided by given delimiter. If some value is not unsigned integer,
 // then it will not be included to result list.
 func (k *Key) ValidUints(delim string) []uint {
-	strs := k.Strings(delim)
-	vals := make([]uint, 0, len(strs))
-	for i := range strs {
-		if val, err := strconv.ParseUint(strs[i], 10, 0); err == nil {
-			vals = append(vals, uint(val))
-		}
-	}
+	vals, _ := k.getUints(delim, false, false)
 	return vals
 }
 
 // ValidUint64s returns list of uint64 divided by given delimiter. If some value is not 64-bit unsigned
 // integer, then it will not be included to result list.
 func (k *Key) ValidUint64s(delim string) []uint64 {
-	strs := k.Strings(delim)
-	vals := make([]uint64, 0, len(strs))
-	for i := range strs {
-		if val, err := strconv.ParseUint(strs[i], 10, 64); err == nil {
-			vals = append(vals, val)
-		}
-	}
+	vals, _ := k.getUint64s(delim, false, false)
 	return vals
 }
 
 // ValidTimesFormat parses with given format and returns list of time.Time divided by given delimiter.
 func (k *Key) ValidTimesFormat(format, delim string) []time.Time {
-	strs := k.Strings(delim)
-	vals := make([]time.Time, 0, len(strs))
-	for i := range strs {
-		if val, err := time.Parse(format, strs[i]); err == nil {
-			vals = append(vals, val)
-		}
-	}
+	vals, _ := k.getTimesFormat(format, delim, false, false)
 	return vals
 }
 
 // ValidTimes parses with RFC3339 format and returns list of time.Time divided by given delimiter.
 func (k *Key) ValidTimes(delim string) []time.Time {
 	return k.ValidTimesFormat(time.RFC3339, delim)
+}
+
+// StrictFloat64s returns list of float64 divided by given delimiter or error on first invalid input.
+func (k *Key) StrictFloat64s(delim string) ([]float64, error) {
+	return k.getFloat64s(delim, false, true)
+}
+
+// StrictInts returns list of int divided by given delimiter or error on first invalid input.
+func (k *Key) StrictInts(delim string) ([]int, error) {
+	return k.getInts(delim, false, true)
+}
+
+// StrictInt64s returns list of int64 divided by given delimiter or error on first invalid input.
+func (k *Key) StrictInt64s(delim string) ([]int64, error) {
+	return k.getInt64s(delim, false, true)
+}
+
+// StrictUints returns list of uint divided by given delimiter or error on first invalid input.
+func (k *Key) StrictUints(delim string) ([]uint, error) {
+	return k.getUints(delim, false, true)
+}
+
+// StrictUint64s returns list of uint64 divided by given delimiter or error on first invalid input.
+func (k *Key) StrictUint64s(delim string) ([]uint64, error) {
+	return k.getUint64s(delim, false, true)
+}
+
+// StrictTimesFormat parses with given format and returns list of time.Time divided by given delimiter
+// or error on first invalid input.
+func (k *Key) StrictTimesFormat(format, delim string) ([]time.Time, error) {
+	return k.getTimesFormat(format, delim, false, true)
+}
+
+// StrictTimes parses with RFC3339 format and returns list of time.Time divided by given delimiter
+// or error on first invalid input.
+func (k *Key) StrictTimes(delim string) ([]time.Time, error) {
+	return k.StrictTimesFormat(time.RFC3339, delim)
+}
+
+// getFloat64s returns list of float64 divided by given delimiter.
+func (k *Key) getFloat64s(delim string, addInvalid, returnOnInvalid bool) ([]float64, error) {
+	strs := k.Strings(delim)
+	vals := make([]float64, 0, len(strs))
+	for _, str := range strs {
+		val, err := strconv.ParseFloat(str, 64)
+		if err != nil && returnOnInvalid {
+			return nil, err
+		}
+		if err == nil || addInvalid {
+			vals = append(vals, val)
+		}
+	}
+	return vals, nil
+}
+
+// getInts returns list of int divided by given delimiter.
+func (k *Key) getInts(delim string, addInvalid, returnOnInvalid bool) ([]int, error) {
+	strs := k.Strings(delim)
+	vals := make([]int, 0, len(strs))
+	for _, str := range strs {
+		val, err := strconv.Atoi(str)
+		if err != nil && returnOnInvalid {
+			return nil, err
+		}
+		if err == nil || addInvalid {
+			vals = append(vals, val)
+		}
+	}
+	return vals, nil
+}
+
+// getInt64s returns list of int64 divided by given delimiter.
+func (k *Key) getInt64s(delim string, addInvalid, returnOnInvalid bool) ([]int64, error) {
+	strs := k.Strings(delim)
+	vals := make([]int64, 0, len(strs))
+	for _, str := range strs {
+		val, err := strconv.ParseInt(str, 10, 64)
+		if err != nil && returnOnInvalid {
+			return nil, err
+		}
+		if err == nil || addInvalid {
+			vals = append(vals, val)
+		}
+	}
+	return vals, nil
+}
+
+// getUints returns list of uint divided by given delimiter.
+func (k *Key) getUints(delim string, addInvalid, returnOnInvalid bool) ([]uint, error) {
+	strs := k.Strings(delim)
+	vals := make([]uint, 0, len(strs))
+	for _, str := range strs {
+		val, err := strconv.ParseUint(str, 10, 0)
+		if err != nil && returnOnInvalid {
+			return nil, err
+		}
+		if err == nil || addInvalid {
+			vals = append(vals, uint(val))
+		}
+	}
+	return vals, nil
+}
+
+// getUint64s returns list of uint64 divided by given delimiter.
+func (k *Key) getUint64s(delim string, addInvalid, returnOnInvalid bool) ([]uint64, error) {
+	strs := k.Strings(delim)
+	vals := make([]uint64, 0, len(strs))
+	for _, str := range strs {
+		val, err := strconv.ParseUint(str, 10, 64)
+		if err != nil && returnOnInvalid {
+			return nil, err
+		}
+		if err == nil || addInvalid {
+			vals = append(vals, val)
+		}
+	}
+	return vals, nil
+}
+
+// getTimesFormat parses with given format and returns list of time.Time divided by given delimiter.
+func (k *Key) getTimesFormat(format, delim string, addInvalid, returnOnInvalid bool) ([]time.Time, error) {
+	strs := k.Strings(delim)
+	vals := make([]time.Time, 0, len(strs))
+	for _, str := range strs {
+		val, err := time.Parse(format, str)
+		if err != nil && returnOnInvalid {
+			return nil, err
+		}
+		if err == nil || addInvalid {
+			vals = append(vals, val)
+		}
+	}
+	return vals, nil
 }
 
 // SetValue changes key value.

--- a/ini.go
+++ b/ini.go
@@ -467,53 +467,67 @@ func (k *Key) Strings(delim string) []string {
 	return vals
 }
 
-// Float64s returns list of float64 divided by given delimiter.
+// Float64s returns list of float64 divided by given delimiter. If some value is not float, then
+// it will not be included to result list.
 func (k *Key) Float64s(delim string) []float64 {
 	strs := k.Strings(delim)
-	vals := make([]float64, len(strs))
+	vals := make([]float64, 0, len(strs))
 	for i := range strs {
-		vals[i], _ = strconv.ParseFloat(strs[i], 64)
+		if val, err := strconv.ParseFloat(strs[i], 64); err == nil {
+			vals = append(vals, val)
+		}
 	}
 	return vals
 }
 
-// Ints returns list of int divided by given delimiter.
+// Ints returns list of int divided by given delimiter. If some value is not integer, then it will
+// not be included to result list.
 func (k *Key) Ints(delim string) []int {
 	strs := k.Strings(delim)
-	vals := make([]int, len(strs))
+	vals := make([]int, 0, len(strs))
 	for i := range strs {
-		vals[i], _ = strconv.Atoi(strs[i])
+		if val, err := strconv.Atoi(strs[i]); err == nil {
+			vals = append(vals, val)
+		}
 	}
 	return vals
 }
 
-// Int64s returns list of int64 divided by given delimiter.
+// Int64s returns list of int64 divided by given delimiter. If some value is not 64-bit integer,
+// then it will not be included to result list.
 func (k *Key) Int64s(delim string) []int64 {
 	strs := k.Strings(delim)
-	vals := make([]int64, len(strs))
+	vals := make([]int64, 0, len(strs))
 	for i := range strs {
-		vals[i], _ = strconv.ParseInt(strs[i], 10, 64)
+		if val, err := strconv.ParseInt(strs[i], 10, 64); err == nil {
+			vals = append(vals, val)
+		}
 	}
 	return vals
 }
 
-// Uints returns list of uint divided by given delimiter.
+// Uints returns list of uint divided by given delimiter. If some value is not unsigned integer,
+// then it will not be included to result list.
 func (k *Key) Uints(delim string) []uint {
 	strs := k.Strings(delim)
-	vals := make([]uint, len(strs))
+	vals := make([]uint, 0, len(strs))
 	for i := range strs {
-		u, _ := strconv.ParseUint(strs[i], 10, 0)
-		vals[i] = uint(u)
+		if val, err := strconv.ParseUint(strs[i], 10, 0); err == nil {
+			vals = append(vals, uint(val))
+		}
 	}
 	return vals
 }
 
-// Uint64s returns list of uint64 divided by given delimiter.
+// Uint64s returns list of uint64 divided by given delimiter. If some value is not 64-bit unsigned
+// integer, then it will not be included to result list.
 func (k *Key) Uint64s(delim string) []uint64 {
 	strs := k.Strings(delim)
-	vals := make([]uint64, len(strs))
+	vals := make([]uint64, 0, len(strs))
 	for i := range strs {
-		vals[i], _ = strconv.ParseUint(strs[i], 10, 64)
+		if val, err := strconv.ParseUint(strs[i], 10, 64); err == nil {
+			vals = append(vals, val)
+		}
 	}
 	return vals
 }
@@ -521,9 +535,11 @@ func (k *Key) Uint64s(delim string) []uint64 {
 // TimesFormat parses with given format and returns list of time.Time divided by given delimiter.
 func (k *Key) TimesFormat(format, delim string) []time.Time {
 	strs := k.Strings(delim)
-	vals := make([]time.Time, len(strs))
+	vals := make([]time.Time, 0, len(strs))
 	for i := range strs {
-		vals[i], _ = time.Parse(format, strs[i])
+		if val, err := time.Parse(format, strs[i]); err == nil {
+			vals = append(vals, val)
+		}
 	}
 	return vals
 }

--- a/ini.go
+++ b/ini.go
@@ -467,7 +467,7 @@ func (k *Key) Strings(delim string) []string {
 	return vals
 }
 
-// Float64s returns list of float64 divided by given delimiter.
+// Float64s returns list of float64 divided by given delimiter. Any invalid input will be treated as zero value.
 func (k *Key) Float64s(delim string) []float64 {
 	strs := k.Strings(delim)
 	vals := make([]float64, len(strs))
@@ -477,7 +477,7 @@ func (k *Key) Float64s(delim string) []float64 {
 	return vals
 }
 
-// Ints returns list of int divided by given delimiter.
+// Ints returns list of int divided by given delimiter. Any invalid input will be treated as zero value.
 func (k *Key) Ints(delim string) []int {
 	strs := k.Strings(delim)
 	vals := make([]int, len(strs))
@@ -487,7 +487,7 @@ func (k *Key) Ints(delim string) []int {
 	return vals
 }
 
-// Int64s returns list of int64 divided by given delimiter.
+// Int64s returns list of int64 divided by given delimiter. Any invalid input will be treated as zero value.
 func (k *Key) Int64s(delim string) []int64 {
 	strs := k.Strings(delim)
 	vals := make([]int64, len(strs))
@@ -497,7 +497,7 @@ func (k *Key) Int64s(delim string) []int64 {
 	return vals
 }
 
-// Uints returns list of uint divided by given delimiter.
+// Uints returns list of uint divided by given delimiter. Any invalid input will be treated as zero value.
 func (k *Key) Uints(delim string) []uint {
 	strs := k.Strings(delim)
 	vals := make([]uint, len(strs))
@@ -508,7 +508,7 @@ func (k *Key) Uints(delim string) []uint {
 	return vals
 }
 
-// Uint64s returns list of uint64 divided by given delimiter.
+// Uint64s returns list of uint64 divided by given delimiter. Any invalid input will be treated as zero value.
 func (k *Key) Uint64s(delim string) []uint64 {
 	strs := k.Strings(delim)
 	vals := make([]uint64, len(strs))
@@ -519,6 +519,7 @@ func (k *Key) Uint64s(delim string) []uint64 {
 }
 
 // TimesFormat parses with given format and returns list of time.Time divided by given delimiter.
+// Any invalid input will be treated as zero value (0001-01-01 00:00:00 +0000 UTC).
 func (k *Key) TimesFormat(format, delim string) []time.Time {
 	strs := k.Strings(delim)
 	vals := make([]time.Time, len(strs))
@@ -529,6 +530,7 @@ func (k *Key) TimesFormat(format, delim string) []time.Time {
 }
 
 // Times parses with RFC3339 format and returns list of time.Time divided by given delimiter.
+// Any invalid input will be treated as zero value (0001-01-01 00:00:00 +0000 UTC).
 func (k *Key) Times(delim string) []time.Time {
 	return k.TimesFormat(time.RFC3339, delim)
 }

--- a/ini_test.go
+++ b/ini_test.go
@@ -382,6 +382,27 @@ func Test_Values(t *testing.T) {
 			}
 		})
 
+		Convey("Get values one type into slice of another type", func() {
+			sec := cfg.Section("array")
+			vals1 := sec.Key("STRINGS").Float64s(",")
+			So(vals1, ShouldBeEmpty)
+
+			vals2 := sec.Key("STRINGS").Ints(",")
+			So(vals2, ShouldBeEmpty)
+
+			vals3 := sec.Key("STRINGS").Int64s(",")
+			So(vals3, ShouldBeEmpty)
+
+			vals4 := sec.Key("STRINGS").Uints(",")
+			So(vals4, ShouldBeEmpty)
+
+			vals5 := sec.Key("STRINGS").Uint64s(",")
+			So(vals5, ShouldBeEmpty)
+
+			vals6 := sec.Key("STRINGS").Times(",")
+			So(vals6, ShouldBeEmpty)
+		})
+
 		Convey("Get key hash", func() {
 			cfg.Section("").KeysHash()
 		})

--- a/ini_test.go
+++ b/ini_test.go
@@ -350,36 +350,68 @@ func Test_Values(t *testing.T) {
 			So(len(sec.Key("STRINGS_404").Strings(",")), ShouldEqual, 0)
 
 			vals1 := sec.Key("FLOAT64S").Float64s(",")
-			for i, v := range []float64{1.1, 2.2, 3.3} {
-				So(vals1[i], ShouldEqual, v)
-			}
+			float64sEqual(vals1, 1.1, 2.2, 3.3)
 
 			vals2 := sec.Key("INTS").Ints(",")
-			for i, v := range []int{1, 2, 3} {
-				So(vals2[i], ShouldEqual, v)
-			}
+			intsEqual(vals2, 1, 2, 3)
 
 			vals3 := sec.Key("INTS").Int64s(",")
-			for i, v := range []int64{1, 2, 3} {
-				So(vals3[i], ShouldEqual, v)
-			}
+			int64sEqual(vals3, 1, 2, 3)
 
 			vals4 := sec.Key("UINTS").Uints(",")
-			for i, v := range []uint{1, 2, 3} {
-				So(vals4[i], ShouldEqual, v)
-			}
+			uintsEqual(vals4, 1, 2, 3)
 
 			vals5 := sec.Key("UINTS").Uint64s(",")
-			for i, v := range []uint64{1, 2, 3} {
-				So(vals5[i], ShouldEqual, v)
-			}
+			uint64sEqual(vals5, 1, 2, 3)
 
 			t, err := time.Parse(time.RFC3339, "2015-01-01T20:17:05Z")
 			So(err, ShouldBeNil)
 			vals6 := sec.Key("TIMES").Times(",")
-			for i, v := range []time.Time{t, t, t} {
-				So(vals6[i].String(), ShouldEqual, v.String())
-			}
+			timesEqual(vals6, t, t, t)
+		})
+
+		Convey("Get valid values into slice", func() {
+			sec := cfg.Section("array")
+			vals1 := sec.Key("FLOAT64S").ValidFloat64s(",")
+			float64sEqual(vals1, 1.1, 2.2, 3.3)
+
+			vals2 := sec.Key("INTS").ValidInts(",")
+			intsEqual(vals2, 1, 2, 3)
+
+			vals3 := sec.Key("INTS").ValidInt64s(",")
+			int64sEqual(vals3, 1, 2, 3)
+
+			vals4 := sec.Key("UINTS").ValidUints(",")
+			uintsEqual(vals4, 1, 2, 3)
+
+			vals5 := sec.Key("UINTS").ValidUint64s(",")
+			uint64sEqual(vals5, 1, 2, 3)
+
+			t, err := time.Parse(time.RFC3339, "2015-01-01T20:17:05Z")
+			So(err, ShouldBeNil)
+			vals6 := sec.Key("TIMES").ValidTimes(",")
+			timesEqual(vals6, t, t, t)
+		})
+
+		Convey("Get values one type into slice of another type", func() {
+			sec := cfg.Section("array")
+			vals1 := sec.Key("STRINGS").ValidFloat64s(",")
+			So(vals1, ShouldBeEmpty)
+
+			vals2 := sec.Key("STRINGS").ValidInts(",")
+			So(vals2, ShouldBeEmpty)
+
+			vals3 := sec.Key("STRINGS").ValidInt64s(",")
+			So(vals3, ShouldBeEmpty)
+
+			vals4 := sec.Key("STRINGS").ValidUints(",")
+			So(vals4, ShouldBeEmpty)
+
+			vals5 := sec.Key("STRINGS").ValidUint64s(",")
+			So(vals5, ShouldBeEmpty)
+
+			vals6 := sec.Key("STRINGS").ValidTimes(",")
+			So(vals6, ShouldBeEmpty)
 		})
 
 		Convey("Get key hash", func() {
@@ -570,5 +602,48 @@ func Benchmark_Key_SetValue(b *testing.B) {
 	c, _ := Load([]byte(_CONF_DATA))
 	for i := 0; i < b.N; i++ {
 		c.Section("").Key("NAME").SetValue("10")
+	}
+}
+
+// Helpers for slice tests.
+func float64sEqual(values []float64, expected ...float64) {
+	So(values, ShouldHaveLength, len(expected))
+	for i, v := range expected {
+		So(values[i], ShouldEqual, v)
+	}
+}
+
+func intsEqual(values []int, expected ...int) {
+	So(values, ShouldHaveLength, len(expected))
+	for i, v := range expected {
+		So(values[i], ShouldEqual, v)
+	}
+}
+
+func int64sEqual(values []int64, expected ...int64) {
+	So(values, ShouldHaveLength, len(expected))
+	for i, v := range expected {
+		So(values[i], ShouldEqual, v)
+	}
+}
+
+func uintsEqual(values []uint, expected ...uint) {
+	So(values, ShouldHaveLength, len(expected))
+	for i, v := range expected {
+		So(values[i], ShouldEqual, v)
+	}
+}
+
+func uint64sEqual(values []uint64, expected ...uint64) {
+	So(values, ShouldHaveLength, len(expected))
+	for i, v := range expected {
+		So(values[i], ShouldEqual, v)
+	}
+}
+
+func timesEqual(values []time.Time, expected ...time.Time) {
+	So(values, ShouldHaveLength, len(expected))
+	for i, v := range expected {
+		So(values[i].String(), ShouldEqual, v.String())
 	}
 }

--- a/ini_test.go
+++ b/ini_test.go
@@ -414,6 +414,62 @@ func Test_Values(t *testing.T) {
 			So(vals6, ShouldBeEmpty)
 		})
 
+		Convey("Get valid values into slice without errors", func() {
+			sec := cfg.Section("array")
+			vals1, err := sec.Key("FLOAT64S").StrictFloat64s(",")
+			So(err, ShouldBeNil)
+			float64sEqual(vals1, 1.1, 2.2, 3.3)
+
+			vals2, err := sec.Key("INTS").StrictInts(",")
+			So(err, ShouldBeNil)
+			intsEqual(vals2, 1, 2, 3)
+
+			vals3, err := sec.Key("INTS").StrictInt64s(",")
+			So(err, ShouldBeNil)
+			int64sEqual(vals3, 1, 2, 3)
+
+			vals4, err := sec.Key("UINTS").StrictUints(",")
+			So(err, ShouldBeNil)
+			uintsEqual(vals4, 1, 2, 3)
+
+			vals5, err := sec.Key("UINTS").StrictUint64s(",")
+			So(err, ShouldBeNil)
+			uint64sEqual(vals5, 1, 2, 3)
+
+			t, err := time.Parse(time.RFC3339, "2015-01-01T20:17:05Z")
+			So(err, ShouldBeNil)
+			vals6, err := sec.Key("TIMES").StrictTimes(",")
+			So(err, ShouldBeNil)
+			timesEqual(vals6, t, t, t)
+		})
+
+		Convey("Get invalid values into slice", func() {
+			sec := cfg.Section("array")
+			vals1, err := sec.Key("STRINGS").StrictFloat64s(",")
+			So(vals1, ShouldBeEmpty)
+			So(err, ShouldNotBeNil)
+
+			vals2, err := sec.Key("STRINGS").StrictInts(",")
+			So(vals2, ShouldBeEmpty)
+			So(err, ShouldNotBeNil)
+
+			vals3, err := sec.Key("STRINGS").StrictInt64s(",")
+			So(vals3, ShouldBeEmpty)
+			So(err, ShouldNotBeNil)
+
+			vals4, err := sec.Key("STRINGS").StrictUints(",")
+			So(vals4, ShouldBeEmpty)
+			So(err, ShouldNotBeNil)
+
+			vals5, err := sec.Key("STRINGS").StrictUint64s(",")
+			So(vals5, ShouldBeEmpty)
+			So(err, ShouldNotBeNil)
+
+			vals6, err := sec.Key("STRINGS").StrictTimes(",")
+			So(vals6, ShouldBeEmpty)
+			So(err, ShouldNotBeNil)
+		})
+
 		Convey("Get key hash", func() {
 			cfg.Section("").KeysHash()
 		})

--- a/ini_test.go
+++ b/ini_test.go
@@ -382,27 +382,6 @@ func Test_Values(t *testing.T) {
 			}
 		})
 
-		Convey("Get values one type into slice of another type", func() {
-			sec := cfg.Section("array")
-			vals1 := sec.Key("STRINGS").Float64s(",")
-			So(vals1, ShouldBeEmpty)
-
-			vals2 := sec.Key("STRINGS").Ints(",")
-			So(vals2, ShouldBeEmpty)
-
-			vals3 := sec.Key("STRINGS").Int64s(",")
-			So(vals3, ShouldBeEmpty)
-
-			vals4 := sec.Key("STRINGS").Uints(",")
-			So(vals4, ShouldBeEmpty)
-
-			vals5 := sec.Key("STRINGS").Uint64s(",")
-			So(vals5, ShouldBeEmpty)
-
-			vals6 := sec.Key("STRINGS").Times(",")
-			So(vals6, ShouldBeEmpty)
-		})
-
 		Convey("Get key hash", func() {
 			cfg.Section("").KeysHash()
 		})


### PR DESCRIPTION
I found that methods that return lists (Float64s, Ints, Int64s and etc.) do not handle parsing errors. For example, following code:
```go
config, _ := Load([]byte(_CONF_DATA))
stringKey := config.Section("array").Key("STRINGS")
fmt.Printf("string values: %v\n", stringKey.Strings(","))
fmt.Printf("float values: %v\n", stringKey.Float64s(","))
```

gives such result:
```
string values: [en zh de]
float values: [0 0 0]
```

I think that the best solution would be to return error from these methods, but it will break down back compatibility of interface.
Therefore I propose do not append to list such values, that was parsed with error.