### PR TITLE
Add LooseLoad - fix #33

### DIFF
--- a/ini_test.go
+++ b/ini_test.go
@@ -116,6 +116,10 @@ func Test_Load(t *testing.T) {
 			cfg, err := Load([]byte(_CONF_DATA), "testdata/conf.ini")
 			So(err, ShouldBeNil)
 			So(cfg, ShouldNotBeNil)
+
+			f, err := Load([]byte(_CONF_DATA), "testdata/404.ini")
+			So(err, ShouldNotBeNil)
+			So(f, ShouldBeNil)
 		})
 	})
 
@@ -166,6 +170,33 @@ func Test_Load(t *testing.T) {
 			So(err, ShouldNotBeNil)
 		})
 	})
+}
+
+func Test_LooseLoad(t *testing.T) {
+	Convey("LooseLoad from data sources", t, func() {
+
+		Convey("LooseLoad from invalid data sources", func() {
+			_, err := LooseLoad(_CONF_DATA)
+			So(err, ShouldBeNil)
+
+			f, err := LooseLoad("testdata/404.ini")
+			So(err, ShouldBeNil)
+			So(f, ShouldNotBeNil)
+
+			_, err = LooseLoad(1)
+			So(err, ShouldNotBeNil)
+
+			_, err = LooseLoad([]byte(""), 1)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("LooseLoad with multiple data sources", func() {
+			cfg, err := LooseLoad([]byte(_CONF_DATA), "testdata/404.ini")
+			So(err, ShouldBeNil)
+			So(cfg, ShouldNotBeNil)
+		})
+	})
+
 }
 
 func Test_File_Append(t *testing.T) {


### PR DESCRIPTION
A common practice in applications development is to allow the user
to customise/extend program's settings by overriding global defaults
set in system-wide config files (typically installed under /etc)
with site-specific copies (e.g. /usr/local/etc) and user-specific
files generally stored in the user's home directory. It must be
noticed that this cascade approach allows the user to specify only
those options that he wishes to override, whilst the other values
will keep their value already set in the other configuration
files. In general, when a program couldn't find any configuration
file rather than crashing it falls back to hardcoded default values.
    
These changes introduce a new function LooseLoad that allows the
caller to pass a slice of filenames without worrying about their
existence or not. LooseLoad will attempt to load them in order.
If a file doesn't just, it will just be ignored and the function
won't return any error. In case no files existed, an empty
configuration will be returned to the caller.

This functionality is inspired by the Python's standard library
configparser.RawConfigParser.read() function:

  https://docs.python.org/2/library/configparser.html#ConfigParser.RawConfigParser.read