### PR TITLE
add value expander

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ func main() {
 }
 ```
 
-which would set the value of `env.Foo` to the value of the environment variable `MY_VAR`
+This would set the value of `env.Foo` to the value of the environment variable `MY_VAR`.
 
 #### Other Notes On Map/Reflect
 

--- a/README.md
+++ b/README.md
@@ -550,6 +550,26 @@ func main() {
 
 Same rules of name mapper apply to `ini.ReflectFromWithMapper` function.
 
+#### Value Mapper
+
+To expand values, e.g. from environment variables, you can use the `ValueMapper` to transform values:
+
+```go
+type Env struct {
+	Foo string `ini:"foo"`
+}
+
+func main() {
+	cfg, err := ini.Load([]byte("[env]\nfoo = ${MY_VAR}\n")
+	cfg.ValueMapper = os.ExpandEnv
+	// ...
+	env := &Env{}
+	err = cfg.Section("env").MapTo(env)
+}
+```
+
+which would set the value of `env.Foo` to the value of the environment variable `MY_VAR`
+
 #### Other Notes On Map/Reflect
 
 Any embedded struct is treated as a section by default, and there is no automatic parent-child relations in map/reflect feature:

--- a/ini.go
+++ b/ini.go
@@ -127,6 +127,8 @@ type File struct {
 	looseMode bool
 
 	NameMapper
+
+	ValueMapper
 }
 
 // newFile initializes File object with given data sources.

--- a/ini.go
+++ b/ini.go
@@ -127,7 +127,6 @@ type File struct {
 	looseMode bool
 
 	NameMapper
-
 	ValueMapper
 }
 

--- a/key.go
+++ b/key.go
@@ -30,6 +30,9 @@ type Key struct {
 	isAutoIncr bool
 }
 
+// ValueMapper represents a mapping function for values, e.g. os.ExpandEnv
+type ValueMapper func(string) string
+
 // Name returns name of key.
 func (k *Key) Name() string {
 	return k.name
@@ -43,6 +46,9 @@ func (k *Key) Value() string {
 // String returns string representation of value.
 func (k *Key) String() string {
 	val := k.value
+	if k.s.f.ValueMapper != nil {
+		val = k.s.f.ValueMapper(val)
+	}
 	if strings.Index(val, "%") == -1 {
 		return val
 	}


### PR DESCRIPTION
This PR lets you transform value with a mapping function. 

It let's you e.g. read a .ini file and expand all ${NAME} in a value with the names value from the environment via `os.ExpandEnv` as `ValueMapper`.