### PR TITLE
Add support for explicitly writing a header in the DEFAULT section

### DIFF
--- a/ini.go
+++ b/ini.go
@@ -56,6 +56,9 @@ var (
 	// Indicate whether to align "=" sign with spaces to produce pretty output
 	// or reduce all possible spaces for compact format.
 	PrettyFormat = true
+
+	// Explicitly write DEFAULT section header
+	DefaultHeader = false
 )
 
 func init() {
@@ -350,7 +353,7 @@ func (f *File) WriteToIndent(w io.Writer, indent string) (n int64, err error) {
 			}
 		}
 
-		if i > 0 {
+		if i > 0 || DefaultHeader {
 			if _, err = buf.WriteString("[" + sname + "]" + LineBreak); err != nil {
 				return 0, err
 			}


### PR DESCRIPTION
Adds support for explicitly writing a header for the DEFAULT section in files. Disabled by default, and can be enabled by setting the following in the implementation of the library:

```
ini.DefaultHeader = true
```

For example:

```
package main

import (
	"github.com/go-ini/ini"
)

func main() {
	ini.DefaultHeader = true
	cfg, _ := ini.Load("config.ini")
	key := cfg.Section("DEFAULT").Key("key1")
	key.SetValue("value2")
	cfg.SaveTo("config.ini")
}
```

Closes #37 