### PR TITLE
Fix calls for KeysHash() in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ names := cfg.Section("").KeyStrings()
 To get a clone hash of keys and corresponding values:
 
 ```go
-hash := cfg.GetSection("").KeysHash()
+hash := cfg.Section("").KeysHash()
 ```
 
 ### Working with values

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -134,7 +134,7 @@ names := cfg.Section("").KeyStrings()
 获取分区下的所有键值对的克隆：
 
 ```go
-hash := cfg.GetSection("").KeysHash()
+hash := cfg.Section("").KeysHash()
 ```
 
 ### 操作键值（Value）


### PR DESCRIPTION
It looks like a typo in README's. I also verified the correct call in `key_test.go`.