### PR TITLE
Match last ] in line when parsing Section header

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -258,7 +258,7 @@ func (f *File) parse(reader io.Reader) (err error) {
 		// Section
 		if line[0] == '[' {
 			// Read to the next ']' (TODO: support quoted strings)
-			closeIdx := bytes.IndexByte(line, ']')
+			closeIdx := bytes.LastIndexByte(line, ']')
 			if closeIdx == -1 {
 				return fmt.Errorf("unclosed section: %s", line)
 			}


### PR DESCRIPTION
I have a config.ini where section names can contain "]", which leads to parse
errors. While proper support for quoting would be best (issue #32) simply
matching the last "]" rather than the first helps in this case.