### PR TITLE
remove # as comment

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -75,7 +75,7 @@ func (p *parser) readUntil(delim byte) ([]byte, error) {
 }
 
 func cleanComment(in []byte) ([]byte, bool) {
-	i := bytes.IndexAny(in, "#;")
+	i := bytes.IndexAny(in, ";")
 	if i == -1 {
 		return nil, false
 	}
@@ -210,7 +210,7 @@ func (p *parser) readValue(in []byte) (string, error) {
 		return p.readContinuationLines(line[:len(line)-1])
 	}
 
-	i := strings.IndexAny(line, "#;")
+	i := strings.IndexAny(line, ";")
 	if i > -1 {
 		p.comment.WriteString(line[i:])
 		line = strings.TrimSpace(line[:i])


### PR DESCRIPTION
situation:

in ini file I have key like
currency_fortmat="$ #"

When parse, it will return only "$

I think there is a better way but this is my workaround please consider and improve it.

thanks