### PR TITLE
Folded tags together, fixed parsing bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,7 +611,7 @@ Age = 21
 ```
 
 ### MapTo special flags
-In addition to the flags mentioned above, you can specify `strictParse` and `mustExist` in a semicolon delimited list on the `iniFlags` tag in a struct definition.  `strictParse` will cause `MapTo` to return an error if a field does not parse to the type specified in the struct instead of silently failing.  `mustExist` will cause an error to be returned if the struct field does not exist in the loaded ini data.
+In addition to the flags mentioned above, you can specify `strict` and `mustExist` in a comma delimited list on the `ini` tag in a struct definition.  `strict` will cause `MapTo` to return an error if a field does not parse to the type specified in the struct instead of silently failing.  `mustExist` will cause an error to be returned if the struct field does not exist in the loaded ini data.  The first value in the `ini` tag must be the field name override as described above.  If no override is desired but other tags are needed, there must be a leading comma before the flag list.
 
 ```ini
 Name = Bob
@@ -621,26 +621,42 @@ Age = thirty
 ```go
 type Person struct {
 	Name string
-	Age int `iniFlags:"strictParse"`
+	Age int `ini:",strict"`
 }
-// Will return error from MapTo.
+// Will return error from MapTo (Field set strict, but Age cannot parse to int).
 ```
 
 ```go
 type Person struct {
 	Name string
 	Age int
-	Salary float64 `iniFlags:"mustExist"`
+	Salary float64 `ini:",mustExist"`
 }
-// Will return error from MapTo.
+// Will return error from MapTo (Salary field set mustExist, but does not exist).
 ```
 
 ```go
 type Person struct {
 	Name string
-	Age int `iniFlags:"strictParse;mustExist"`
+	Age int `ini:",strict,mustExist"`
 }
-// Will return error from MapTo.
+// Will return error from MapTo (Field set strict, but Age cannot parse to int).
+```
+
+```go
+type Person struct {
+	MyName string `ini:"Name,strict"`
+	Age int
+}
+// Will map without error.
+```
+
+```go
+type Person struct {
+	Name string `ini:"MyName,mustExist,strict"`
+	Age int
+}
+// Will return error from MapTo (No field MyName and mustExist).
 ```
 
 ## Getting Help

--- a/README.md
+++ b/README.md
@@ -611,7 +611,7 @@ Age = 21
 ```
 
 ### MapTo special flags
-In addition to the flags mentioned above, you can specify `strictParse` and `mustExist` in a semicolon delimited list on the `iniFlags` tag in a struct definition.  `strictParse` will cause `MapTo` to return an error if a field does not parse to the type specified in the strict instead of silently failing.  `mustExist` will cause an error to be returned if the struct field does not exist in the loaded ini data.
+In addition to the flags mentioned above, you can specify `strictParse` and `mustExist` in a semicolon delimited list on the `iniFlags` tag in a struct definition.  `strictParse` will cause `MapTo` to return an error if a field does not parse to the type specified in the struct instead of silently failing.  `mustExist` will cause an error to be returned if the struct field does not exist in the loaded ini data.
 
 ```ini
 Name = Bob

--- a/README.md
+++ b/README.md
@@ -610,6 +610,39 @@ Name = Unknwon
 Age = 21
 ```
 
+### MapTo special flags
+In addition to the flags mentioned above, you can specify `strictParse` and `mustExist` in a semicolon delimited list on the `iniFlags` tag in a struct definition.  `strictParse` will cause `MapTo` to return an error if a field does not parse to the type specified in the strict instead of silently failing.  `mustExist` will cause an error to be returned if the struct field does not exist in the loaded ini data.
+
+```ini
+Name = Bob
+Age = thirty
+```
+
+```go
+type Person struct {
+	Name string
+	Age int `iniFlags:"strictParse"`
+}
+// Will return error from MapTo.
+```
+
+```go
+type Person struct {
+	Name string
+	Age int
+	Salary float64 `iniFlags:"mustExist"`
+}
+// Will return error from MapTo.
+```
+
+```go
+type Person struct {
+	Name string
+	Age int `iniFlags:"strictParse;mustExist"`
+}
+// Will return error from MapTo.
+```
+
 ## Getting Help
 
 - [API Documentation](https://gowalker.org/gopkg.in/ini.v1)

--- a/README.md
+++ b/README.md
@@ -519,6 +519,38 @@ Places = HangZhou,Boston
 None =
 ```
 
+What if I want to compose a struct template of other structs?
+
+### Struct pointers as field types
+
+```ini
+Foo=1
+[Bar1]
+Baz=2
+[Bar2]
+Baz=3
+```
+
+```go
+type Bar struct {
+	Baz int
+}
+
+type FullIni struct {
+	Foo int
+	Bar1 *Bar
+	Bar2 *Bar
+}
+
+func main() {
+	cfg, err := ini.Load("path/to/ini")
+	// ...
+	i := new(FullIni)
+	err = cfg.MapTo(i)
+	// ...
+}
+```
+
 #### Name Mapper
 
 To save your time and make your code cleaner, this library supports [`NameMapper`](https://gowalker.org/gopkg.in/ini.v1#NameMapper) between struct field and actual section and key name.

--- a/struct.go
+++ b/struct.go
@@ -242,19 +242,13 @@ func setWithProperTypeWithFlags(t reflect.Type, key *Key, field reflect.Value, d
 }
 
 func (s *Section) mapTo(val reflect.Value) error {
-	fmt.Println(val)
-	var typ reflect.Type
 	if val.Kind() == reflect.Ptr {
-		fmt.Println(val, "is ptr")
 		val = val.Elem()
 	}
-	typ = val.Type()
-	//typ = reflect.TypeOf(val)
-	//fmt.Println(val, "typeof", typ)
+	typ := val.Type()
 	for i := 0; i < typ.NumField(); i++ {
 		field := val.Field(i)
 		tpField := typ.Field(i)
-		fmt.Println("iter", field, tpField)
 
 		tag := tpField.Tag.Get("ini")
 		flags := make(map[string]bool)
@@ -273,17 +267,10 @@ func (s *Section) mapTo(val reflect.Value) error {
 		isAnonymous := tpField.Type.Kind() == reflect.Ptr && tpField.Anonymous
 		isStruct := tpField.Type.Kind() == reflect.Struct
 		isStructPtr := tpField.Type.Kind() == reflect.Ptr && reflect.TypeOf(field.Elem()).Kind() == reflect.Struct
-		fmt.Println(val, field, isAnonymous, isStruct, isStructPtr)
 		if isStructPtr {
-			fmt.Println("struct ptr")
 			if field.Elem() == reflect.Zero(reflect.TypeOf(field.Elem())).Interface() {
-				fmt.Println("got zero")
-				fmt.Println(field.Elem(), reflect.TypeOf(field.Elem()), tpField.Type)
 				field.Set(reflect.New(tpField.Type.Elem()))
 			}
-			// fmt.Println("before", field)
-			// field = field.Elem()
-			// fmt.Println("after", field)
 		} else if isAnonymous {
 			field.Set(reflect.New(tpField.Type.Elem()))
 		}

--- a/struct.go
+++ b/struct.go
@@ -19,9 +19,9 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 	"unicode"
-	"strings"
 )
 
 // NameMapper represents a ini tag name mapper.
@@ -112,7 +112,7 @@ func setIntLike(key *Key, field reflect.Value, retrievedValue reflect.Value, ret
 	} else if retrievedValue.Int() != 0 {
 		field.SetInt(retrievedValue.Int())
 		return nil
-	// Parse duration returns error on empty string
+		// Parse duration returns error on empty string
 	} else if fieldTypeName == "duration" && retrievedValue.Int() == 0 {
 		field.SetInt(retrievedValue.Int())
 		return nil
@@ -139,7 +139,7 @@ func setUintLike(key *Key, field reflect.Value, retrievedValue reflect.Value, re
 	} else if retrievedValue.Uint() != 0 {
 		field.SetUint(retrievedValue.Uint())
 		return nil
-	// Parse duration returns error on empty string
+		// Parse duration returns error on empty string
 	} else if fieldTypeName == "duration" && retrievedValue.Int() == 0 {
 		field.SetUint(retrievedValue.Uint())
 		return nil
@@ -153,7 +153,6 @@ func setUintLike(key *Key, field reflect.Value, retrievedValue reflect.Value, re
 		}
 	}
 }
-
 
 // setWithProperTypeWithFlags sets proper value to field based on its type,
 // returning errors during parsing based on flags provided.

--- a/struct.go
+++ b/struct.go
@@ -293,10 +293,10 @@ func (s *Section) mapTo(val reflect.Value) error {
 				if err = sec.mapTo(field); err != nil {
 					return fmt.Errorf("error mapping field(%s): %v", fieldName, err)
 				}
-				continue
 			} else if flags["mustExist"] {
 				return fmt.Errorf("%s defined with mustExist but field(%s) not found in loaded data: %v", tpField.Name, fieldName, err)
 			}
+			continue
 		}
 
 		//if tpFiled.Type.Kind() ==

--- a/struct.go
+++ b/struct.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"time"
 	"unicode"
+	"strings"
 )
 
 // NameMapper represents a ini tag name mapper.
@@ -80,62 +81,114 @@ var reflectTime = reflect.TypeOf(time.Now()).Kind()
 // but it does not return error for failing parsing,
 // because we want to use default value that is already assigned to strcut.
 func setWithProperType(t reflect.Type, key *Key, field reflect.Value, delim string) error {
+	return setWithProperTypeWithFlags(t, key, field, delim, make(map[string]bool))
+}
+
+func handleParseError(key *Key, flags map[string]bool, targetTypeName string) error {
+	if flags["strictParse"] {
+		var val string
+		if targetTypeName == "string" {
+			val = "<string parse failure>"
+		} else {
+			val = key.String()
+			if len(val) == 0 {
+				val = "<empty or could not parse as string>"
+			}
+		}
+		return fmt.Errorf("strictParse set on field, but '%s' could not parse as %s.", val, targetTypeName)
+	}
+	return nil
+}
+
+func setIntLike(key *Key, field reflect.Value, retrievedValue reflect.Value, retrievalError error, flags map[string]bool, fieldTypeName string) error {
+	// force parse failure errors so upstream can handle
+	strictFlags := make(map[string]bool)
+	for flag, value := range flags {
+		strictFlags[flag] = value
+	}
+	strictFlags["strictParse"] = true
+	if retrievalError != nil {
+		return handleParseError(key, strictFlags, fieldTypeName)
+	} else if retrievedValue.Int() != 0 {
+		field.SetInt(retrievedValue.Int())
+		return nil
+	// Parse duration returns error on empty string
+	} else if fieldTypeName == "duration" && retrievedValue.Int() == 0 {
+		field.SetInt(retrievedValue.Int())
+		return nil
+	} else {
+		str := key.String()
+		if str != "0" && str != "-0" {
+			return handleParseError(key, strictFlags, fieldTypeName)
+		} else {
+			field.SetInt(retrievedValue.Int())
+			return nil
+		}
+	}
+}
+
+// setWithProperTypeWithFlags sets proper value to field based on its type,
+// returning errors during parsing based on flags provided.
+func setWithProperTypeWithFlags(t reflect.Type, key *Key, field reflect.Value, delim string, flags map[string]bool) error {
 	switch t.Kind() {
 	case reflect.String:
 		if len(key.String()) == 0 {
-			return nil
+			return handleParseError(key, flags, "string")
 		}
 		field.SetString(key.String())
 	case reflect.Bool:
 		boolVal, err := key.Bool()
 		if err != nil {
-			return nil
+			return handleParseError(key, flags, "bool")
 		}
 		field.SetBool(boolVal)
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		durationVal, err := key.Duration()
-		// Skip zero value
-		if err == nil && int(durationVal) > 0 {
-			field.Set(reflect.ValueOf(durationVal))
-			return nil
-		}
-
 		intVal, err := key.Int64()
-		if err != nil || intVal == 0 {
-			return nil
+		intErr := setIntLike(key, field, reflect.ValueOf(intVal), err, flags, "int")
+		if intErr != nil {
+			durVal, err := key.Duration()
+			durErr := setIntLike(key, field, reflect.ValueOf(durVal), err, flags, "duration")
+			if durErr != nil {
+				if flags["strictParse"] {
+					return intErr
+				} else {
+					return nil
+				}
+			}
 		}
-		field.SetInt(intVal)
 	//	byte is an alias for uint8, so supporting uint8 breaks support for byte
 	case reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		durationVal, err := key.Duration()
-		if err == nil {
-			field.Set(reflect.ValueOf(durationVal))
-			return nil
-		}
-
 		uintVal, err := key.Uint64()
-		if err != nil {
-			return nil
+		intErr := setIntLike(key, field, reflect.ValueOf(uintVal), err, flags, "uint")
+		if intErr != nil {
+			durVal, err := key.Duration()
+			durErr := setIntLike(key, field, reflect.ValueOf(durVal), err, flags, "duration")
+			if durErr != nil {
+				if flags["strictParse"] {
+					return intErr
+				} else {
+					return nil
+				}
+			}
 		}
-		field.SetUint(uintVal)
 
 	case reflect.Float64:
 		floatVal, err := key.Float64()
 		if err != nil {
-			return nil
+			return handleParseError(key, flags, "float")
 		}
 		field.SetFloat(floatVal)
 	case reflectTime:
 		timeVal, err := key.Time()
 		if err != nil {
-			return nil
+			return handleParseError(key, flags, "time")
 		}
 		field.Set(reflect.ValueOf(timeVal))
 	case reflect.Slice:
 		vals := key.Strings(delim)
 		numVals := len(vals)
 		if numVals == 0 {
-			return nil
+			return handleParseError(key, flags, "slice")
 		}
 
 		sliceOf := field.Type().Elem().Kind()
@@ -172,6 +225,10 @@ func (s *Section) mapTo(val reflect.Value) error {
 		tpField := typ.Field(i)
 
 		tag := tpField.Tag.Get("ini")
+		flags := make(map[string]bool)
+		for _, flag := range strings.Split(tpField.Tag.Get("iniFlags"), ";") {
+			flags[flag] = true
+		}
 		if tag == "-" {
 			continue
 		}
@@ -193,13 +250,17 @@ func (s *Section) mapTo(val reflect.Value) error {
 					return fmt.Errorf("error mapping field(%s): %v", fieldName, err)
 				}
 				continue
+			} else if flags["mustExist"] {
+				return fmt.Errorf("%s defined with mustExist but field(%s) not found in loaded data: %v", tpField.Name, fieldName, err)
 			}
 		}
 
 		if key, err := s.GetKey(fieldName); err == nil {
-			if err = setWithProperType(tpField.Type, key, field, parseDelim(tpField.Tag.Get("delim"))); err != nil {
+			if err = setWithProperTypeWithFlags(tpField.Type, key, field, parseDelim(tpField.Tag.Get("delim")), flags); err != nil {
 				return fmt.Errorf("error mapping field(%s): %v", fieldName, err)
 			}
+		} else if flags["mustExist"] {
+			return fmt.Errorf("%s defined with mustExist but field(%s) not found in loaded data: %v", tpField.Name, fieldName, err)
 		}
 	}
 	return nil

--- a/struct.go
+++ b/struct.go
@@ -242,14 +242,19 @@ func setWithProperTypeWithFlags(t reflect.Type, key *Key, field reflect.Value, d
 }
 
 func (s *Section) mapTo(val reflect.Value) error {
+	fmt.Println(val)
+	var typ reflect.Type
 	if val.Kind() == reflect.Ptr {
+		fmt.Println(val, "is ptr")
 		val = val.Elem()
 	}
-	typ := val.Type()
-
+	typ = val.Type()
+	//typ = reflect.TypeOf(val)
+	//fmt.Println(val, "typeof", typ)
 	for i := 0; i < typ.NumField(); i++ {
 		field := val.Field(i)
 		tpField := typ.Field(i)
+		fmt.Println("iter", field, tpField)
 
 		tag := tpField.Tag.Get("ini")
 		flags := make(map[string]bool)
@@ -267,11 +272,23 @@ func (s *Section) mapTo(val reflect.Value) error {
 
 		isAnonymous := tpField.Type.Kind() == reflect.Ptr && tpField.Anonymous
 		isStruct := tpField.Type.Kind() == reflect.Struct
-		if isAnonymous {
+		isStructPtr := tpField.Type.Kind() == reflect.Ptr && reflect.TypeOf(field.Elem()).Kind() == reflect.Struct
+		fmt.Println(val, field, isAnonymous, isStruct, isStructPtr)
+		if isStructPtr {
+			fmt.Println("struct ptr")
+			if field.Elem() == reflect.Zero(reflect.TypeOf(field.Elem())).Interface() {
+				fmt.Println("got zero")
+				fmt.Println(field.Elem(), reflect.TypeOf(field.Elem()), tpField.Type)
+				field.Set(reflect.New(tpField.Type.Elem()))
+			}
+			// fmt.Println("before", field)
+			// field = field.Elem()
+			// fmt.Println("after", field)
+		} else if isAnonymous {
 			field.Set(reflect.New(tpField.Type.Elem()))
 		}
 
-		if isAnonymous || isStruct {
+		if isAnonymous || isStruct || isStructPtr {
 			if sec, err := s.f.GetSection(fieldName); err == nil {
 				if err = sec.mapTo(field); err != nil {
 					return fmt.Errorf("error mapping field(%s): %v", fieldName, err)
@@ -281,6 +298,8 @@ func (s *Section) mapTo(val reflect.Value) error {
 				return fmt.Errorf("%s defined with mustExist but field(%s) not found in loaded data: %v", tpField.Name, fieldName, err)
 			}
 		}
+
+		//if tpFiled.Type.Kind() ==
 
 		if key, err := s.GetKey(fieldName); err == nil {
 			if err = setWithProperTypeWithFlags(tpField.Type, key, field, parseDelim(tpField.Tag.Get("delim")), flags); err != nil {

--- a/struct_test.go
+++ b/struct_test.go
@@ -47,17 +47,17 @@ type testStruct struct {
 }
 
 type testStructPassingFlags struct {
-	Name string `ini:"NAME" iniFlags:"mustExist"`
-	Age  int    `iniFlags:"strictParse"`
-	Male bool   `iniFlags:"mustExist;strictParse"`
+	Name string `ini:"NAME,mustExist"`
+	Age  int    `ini:",strict"`
+	Male bool   `ini:",mustExist,strict"`
 }
 
 type testStructFailingMustExistFlag struct {
-	Job string `iniFlags:"mustExist"`
+	Job string `ini:",mustExist"`
 }
 
 type testStructFailingStrictParseFlag struct {
-	Name int `ini:"NAME" iniFlags:"strictParse"`
+	Name int `ini:"NAME,strict"`
 }
 
 const _CONF_DATA_STRUCT = `

--- a/struct_test.go
+++ b/struct_test.go
@@ -46,8 +46,22 @@ type testStruct struct {
 	Unsigned     uint
 }
 
+type testStructPassingFlags struct {
+	Name		string `ini:"NAME" iniFlags:"mustExist"`
+	Age			int `iniFlags:"strictParse"`
+	Male		bool `iniFlags:"mustExist;strictParse"`
+}
+
+type testStructFailingMustExistFlag struct {
+	Job			string `iniFlags:"mustExist"`
+}
+
+type testStructFailingStrictParseFlag struct {
+	Name		int `ini:"NAME" iniFlags:"strictParse"`
+}
+
 const _CONF_DATA_STRUCT = `
-NAME = Unknwon
+NAME = Unknown
 Age = 21
 Male = true
 Money = 1.25
@@ -108,13 +122,28 @@ Born = nil
 Cities = 
 `
 
+type zeroValueDataStruct struct {
+	ZeroAge			int
+	ZeroMoney		float64
+	ZeroDuration	time.Duration
+	Age				int
+	Money			float64
+}
+
+const _ZERO_VALUE_DATA_CONF_STRUCT = `
+ZeroAge = 0
+ZeroMoney = 0.0
+ZeroDuration = 0
+Age =
+`
+
 func Test_Struct(t *testing.T) {
 	Convey("Map to struct", t, func() {
 		Convey("Map file to struct", func() {
 			ts := new(testStruct)
 			So(MapTo(ts, []byte(_CONF_DATA_STRUCT)), ShouldBeNil)
 
-			So(ts.Name, ShouldEqual, "Unknwon")
+			So(ts.Name, ShouldEqual, "Unknown")
 			So(ts.Age, ShouldEqual, 21)
 			So(ts.Male, ShouldBeTrue)
 			So(ts.Money, ShouldEqual, 1.25)
@@ -187,6 +216,40 @@ func Test_Struct(t *testing.T) {
 			So(dv.Born.String(), ShouldEqual, t.String())
 			So(strings.Join(dv.Cities, ","), ShouldEqual, "HangZhou,Boston")
 		})
+		Convey("Map to struct with passing iniFlags", func() {
+			cfg, err := Load([]byte(_CONF_DATA_STRUCT))
+			So(err, ShouldBeNil)
+			testStruct := new(testStructPassingFlags)
+			So(cfg.MapTo(testStruct), ShouldBeNil)
+			So(testStruct.Name, ShouldEqual, "Unknown")
+			So(testStruct.Age, ShouldEqual, 21)
+			So(testStruct.Male, ShouldBeTrue)
+		})
+		Convey("Map to struct with failing strictParse", func() {
+			cfg, err := Load([]byte(_CONF_DATA_STRUCT))
+			So(err, ShouldBeNil)
+			So(cfg.MapTo(&testStructFailingStrictParseFlag{}), ShouldNotBeNil)
+		})
+		Convey("Map to struct with failing mustExist", func() {
+			cfg, err := Load([]byte(_CONF_DATA_STRUCT))
+			So(err, ShouldBeNil)
+			So(cfg.MapTo(&testStructFailingMustExistFlag{}), ShouldNotBeNil)
+		})
+		Convey("Map to struct with defaults overridden by 0 vals in ini", func(){
+			cfg, err := Load([]byte(_ZERO_VALUE_DATA_CONF_STRUCT))
+			So(err, ShouldBeNil)
+			testStruct := &zeroValueDataStruct{ZeroAge: 3,
+											   ZeroMoney: 2.2,
+											   ZeroDuration: 25,
+											   Age: 3,
+											   Money: 2.2}
+			So(cfg.MapTo(testStruct), ShouldBeNil)
+			So(testStruct.ZeroAge, ShouldEqual, 0)
+			So(testStruct.ZeroMoney, ShouldEqual, 0)
+			So(testStruct.ZeroDuration, ShouldEqual, 0)
+			So(testStruct.Age, ShouldEqual, 3)
+			So(testStruct.Money, ShouldEqual, 2.2)
+		})
 	})
 
 	Convey("Reflect from struct", t, func() {
@@ -203,7 +266,7 @@ func Test_Struct(t *testing.T) {
 			NeverMind string `ini:"-"`
 			*Embeded  `ini:"infos"`
 		}
-		a := &Author{"Unknwon", true, 21, 2.8, "",
+		a := &Author{"Unknown", true, 21, 2.8, "",
 			&Embeded{
 				[]time.Time{time.Now(), time.Now()},
 				[]string{"HangZhou", "Boston"},

--- a/struct_test.go
+++ b/struct_test.go
@@ -47,17 +47,17 @@ type testStruct struct {
 }
 
 type testStructPassingFlags struct {
-	Name		string `ini:"NAME" iniFlags:"mustExist"`
-	Age			int `iniFlags:"strictParse"`
-	Male		bool `iniFlags:"mustExist;strictParse"`
+	Name string `ini:"NAME" iniFlags:"mustExist"`
+	Age  int    `iniFlags:"strictParse"`
+	Male bool   `iniFlags:"mustExist;strictParse"`
 }
 
 type testStructFailingMustExistFlag struct {
-	Job			string `iniFlags:"mustExist"`
+	Job string `iniFlags:"mustExist"`
 }
 
 type testStructFailingStrictParseFlag struct {
-	Name		int `ini:"NAME" iniFlags:"strictParse"`
+	Name int `ini:"NAME" iniFlags:"strictParse"`
 }
 
 const _CONF_DATA_STRUCT = `
@@ -123,11 +123,11 @@ Cities =
 `
 
 type zeroValueDataStruct struct {
-	ZeroAge			int
-	ZeroMoney		float64
-	ZeroDuration	time.Duration
-	Age				int
-	Money			float64
+	ZeroAge      int
+	ZeroMoney    float64
+	ZeroDuration time.Duration
+	Age          int
+	Money        float64
 }
 
 const _ZERO_VALUE_DATA_CONF_STRUCT = `
@@ -235,14 +235,14 @@ func Test_Struct(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(cfg.MapTo(&testStructFailingMustExistFlag{}), ShouldNotBeNil)
 		})
-		Convey("Map to struct with defaults overridden by 0 vals in ini", func(){
+		Convey("Map to struct with defaults overridden by 0 vals in ini", func() {
 			cfg, err := Load([]byte(_ZERO_VALUE_DATA_CONF_STRUCT))
 			So(err, ShouldBeNil)
 			testStruct := &zeroValueDataStruct{ZeroAge: 3,
-											   ZeroMoney: 2.2,
-											   ZeroDuration: 25,
-											   Age: 3,
-											   Money: 2.2}
+				ZeroMoney:    2.2,
+				ZeroDuration: 25,
+				Age:          3,
+				Money:        2.2}
 			So(cfg.MapTo(testStruct), ShouldBeNil)
 			So(testStruct.ZeroAge, ShouldEqual, 0)
 			So(testStruct.ZeroMoney, ShouldEqual, 0)


### PR DESCRIPTION
`ini` and `iniFlags` now all live in `ini`
Partially fixed bug in time.Time field parsing.  Fixing fully will take a broader refactor, as the buggy assumption is built in to the parser at a pretty low level.  The fundamental problem is that `reflect.TypeOf(time.Now()).Kind() == reflect.Struct` (and other complex types as well), and the parser assumes that you can accurately differentiate types for parsing based on Kind().