### PR TITLE
Retrieve parent keys available to a child section

### DIFF
--- a/key_test.go
+++ b/key_test.go
@@ -59,6 +59,13 @@ func Test_Key(t *testing.T) {
 			}
 		})
 
+		Convey("Get parent-keys that are available to the child section", func() {
+			parentKeys := cfg.Section("package.sub").ParentKeys()
+			for _, k := range parentKeys {
+				So(k.Name(), ShouldEqual, "CLONE_URL")
+			}
+		})
+
 		Convey("Get overwrite value", func() {
 			So(cfg.Section("author").Key("E-MAIL").String(), ShouldEqual, "u@gogs.io")
 		})

--- a/section.go
+++ b/section.go
@@ -139,6 +139,26 @@ func (s *Section) Keys() []*Key {
 	return keys
 }
 
+// ParentKeys returns list of keys of parent section.
+func (s * Section) ParentKeys() []*Key {
+	var parentKeys []*Key
+	sname := s.name
+	for {
+		if i := strings.LastIndex(sname, "."); i > -1 {
+			sname = sname[:i]
+			sec, err := s.f.GetSection(sname)
+			if err != nil {
+				continue
+			}
+			parentKeys = append(parentKeys, sec.Keys()...)
+		} else {
+			break
+		}
+
+	}
+	return parentKeys
+}
+
 // KeyStrings returns list of key names of section.
 func (s *Section) KeyStrings() []string {
 	list := make([]string, len(s.keyList))


### PR DESCRIPTION
This PR lets us retrieve a list of parent keys that are
available to the child section.