### PR TITLE
Fix panic from incorrect alignment length calculation

### DIFF
--- a/ini.go
+++ b/ini.go
@@ -364,12 +364,22 @@ func (f *File) WriteToIndent(w io.Writer, indent string) (n int64, err error) {
 			}
 		}
 
-		// Count and generate alignment length and buffer spaces
+		// Count and generate alignment length and buffer spaces using the
+		// longest key. Keys may be modifed if they contain certain characters so
+		// we need to take that into account in our calculation.
 		alignLength := 0
 		if PrettyFormat {
-			for i := 0; i < len(sec.keyList); i++ {
-				if len(sec.keyList[i]) > alignLength {
-					alignLength = len(sec.keyList[i])
+			for _, kname := range sec.keyList {
+				keyLength := len(kname)
+				// First case will surround key by ` and second by """
+				if strings.ContainsAny(kname, "\"=:") {
+					keyLength += 2
+				} else if strings.Contains(kname, "`") {
+					keyLength += 6
+				}
+
+				if keyLength > alignLength {
+					alignLength = keyLength
 				}
 			}
 		}

--- a/ini_test.go
+++ b/ini_test.go
@@ -226,6 +226,7 @@ func Test_File_SaveTo(t *testing.T) {
 		cfg.Section("author").Comment = `Information about package author
 # Bio can be written in multiple lines.`
 		cfg.Section("advanced").Key("val w/ pound").SetValue("my#password")
+		cfg.Section("advanced").Key("longest key has a colon : yes/no").SetValue("yes")
 		So(cfg.SaveTo("testdata/conf_out.ini"), ShouldBeNil)
 
 		cfg.Section("author").Key("NAME").Comment = "This is author name"


### PR DESCRIPTION
The alignment length calculation did not take into account that
keys may be added to if they contained "\"", "=", ":", or "`".

This gave an under calculation and resulted in index out of
bounds when this happened to be the longest key.

Please feel free to give any feedback or issues with the following request