### PR TITLE
Add support for omitempty tag option

### DIFF
--- a/struct_test.go
+++ b/struct_test.go
@@ -269,6 +269,38 @@ None        =
 		Convey("Reflect from non-point struct", func() {
 			So(ReflectFrom(cfg, Author{}), ShouldNotBeNil)
 		})
+
+		Convey("Reflect from struct with omitempty", func() {
+			cfg := Empty()
+			type SpecialStruct struct {
+				FirstName  string    `ini:"first_name"`
+				LastName   string    `ini:"last_name"`
+				JustOmitMe string    `ini:"omitempty"`
+				LastLogin  time.Time `ini:"last_login,omitempty"`
+				LastLogin2 time.Time `ini:",omitempty"`
+				NotEmpty   int       `ini:"omitempty"`
+			}
+
+			So(ReflectFrom(cfg, &SpecialStruct{FirstName: "John", LastName: "Doe", NotEmpty: 9}), ShouldBeNil)
+
+			var buf bytes.Buffer
+			_, err = cfg.WriteTo(&buf)
+			So(buf.String(), ShouldEqual, `first_name = John
+last_name  = Doe
+omitempty  = 9
+
+`)
+		})
+
+		Convey("Reflect from struct with too many opts in a tag", func() {
+			cfg := Empty()
+			type SpecialStruct struct {
+				TooManyOpts string `ini:"first_name,second,third"`
+				LastName    string `ini:"last_name"`
+			}
+
+			So(ReflectFrom(cfg, &SpecialStruct{TooManyOpts: "John", LastName: "Doe"}), ShouldNotBeNil)
+		})
 	})
 }
 


### PR DESCRIPTION
Closes #59

The `isEmptyValue` is shamelessly stolen from https://github.com/golang/go/tree/master/src/encoding/json , I just added support for `time.Time`. 😉 
