### PR TITLE
boolean keys do not get sanitised from the \n

### DIFF
--- a/ini.go
+++ b/ini.go
@@ -472,6 +472,9 @@ func (f *File) WriteToIndent(w io.Writer, indent string) (n int64, err error) {
 			}
 
 			if key.isBooleanType {
+				if kname != sec.keyList[len(sec.keyList)-1] {
+					buf.WriteString(LineBreak)
+				}
 				continue
 			}
 

--- a/ini_test.go
+++ b/ini_test.go
@@ -206,16 +206,21 @@ key2=c\d\`))
 
 	Convey("Load with boolean type keys", t, func() {
 		cfg, err := LoadSources(LoadOptions{AllowBooleanKeys: true}, []byte(`key1=hello
-key2`))
+key2
+#key3
+key4`))
 		So(err, ShouldBeNil)
 		So(cfg, ShouldNotBeNil)
 
+		// it fails in presence of a #commented out line, the previous key keeps a trailing \n
+		So(strings.Join(cfg.Section("").KeyStrings(), ","), ShouldEqual, "key1,key2,key4")
 		So(cfg.Section("").Key("key2").MustBool(false), ShouldBeTrue)
 
 		var buf bytes.Buffer
 		cfg.WriteTo(&buf)
 		So(buf.String(), ShouldEqual, `key1 = hello
 key2
+key4
 `)
 	})
 }

--- a/ini_test.go
+++ b/ini_test.go
@@ -213,7 +213,6 @@ key5`))
 		So(err, ShouldBeNil)
 		So(cfg, ShouldNotBeNil)
 
-		// it fails in presence of a #commented out line, the previous key keeps a trailing \n
 		So(strings.Join(cfg.Section("").KeyStrings(), ","), ShouldEqual, "key1,key2,key4,key5")
 		So(cfg.Section("").Key("key2").MustBool(false), ShouldBeTrue)
 

--- a/ini_test.go
+++ b/ini_test.go
@@ -219,8 +219,10 @@ key5`))
 
 		var buf bytes.Buffer
 		cfg.WriteTo(&buf)
+		// there is always a trailing \n at the end of the section
 		So(buf.String(), ShouldEqual, `key1 = hello
 key2
+#key3
 key4
 key5
 `)

--- a/ini_test.go
+++ b/ini_test.go
@@ -208,12 +208,13 @@ key2=c\d\`))
 		cfg, err := LoadSources(LoadOptions{AllowBooleanKeys: true}, []byte(`key1=hello
 key2
 #key3
-key4`))
+key4
+key5`))
 		So(err, ShouldBeNil)
 		So(cfg, ShouldNotBeNil)
 
 		// it fails in presence of a #commented out line, the previous key keeps a trailing \n
-		So(strings.Join(cfg.Section("").KeyStrings(), ","), ShouldEqual, "key1,key2,key4")
+		So(strings.Join(cfg.Section("").KeyStrings(), ","), ShouldEqual, "key1,key2,key4,key5")
 		So(cfg.Section("").Key("key2").MustBool(false), ShouldBeTrue)
 
 		var buf bytes.Buffer
@@ -221,6 +222,7 @@ key4`))
 		So(buf.String(), ShouldEqual, `key1 = hello
 key2
 key4
+key5
 `)
 	})
 }

--- a/ini_test.go
+++ b/ini_test.go
@@ -17,6 +17,7 @@ package ini
 import (
 	"bytes"
 	"io/ioutil"
+	"strings"
 	"testing"
 	"time"
 

--- a/parser.go
+++ b/parser.go
@@ -318,7 +318,8 @@ func (f *File) parse(reader io.Reader) (err error) {
 		if err != nil {
 			// Treat as boolean key when desired, and whole line is key name.
 			if IsErrDelimiterNotFound(err) && f.options.AllowBooleanKeys {
-				key, err := section.NewKey(string(line), "true")
+				kname, err := p.readValue(line, f.options.IgnoreContinuation)
+				key, err := section.NewKey(kname, "true")
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
I would have loved to provide as well a patch... 
I'll try, but maybe someone else is faster than me

here is a unit test that properly isolates the problem