### PR TITLE
Config pointer does not have GetKey directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ sec1, err := cfg.GetSection("Section")
 sec2, err := cfg.GetSection("SecTIOn")
 
 // key1 and key2 are the exactly same key object
-key1, err := cfg.GetKey("Key")
-key2, err := cfg.GetKey("KeY")
+key1, err := sec1.GetKey("Key")
+key2, err := sec2.GetKey("KeY")
 ```
 
 #### MySQL-like boolean key 


### PR DESCRIPTION
Section has GetKey function, and not config pointer directly.

```
cmd/export.go:32: cfg.GetKey undefined (type *ini.File has no field or method GetKey)
```