### PR TITLE
直接使用包级别的映射函数时，设置 cfg.BlockMode = false

### DIFF
--- a/struct.go
+++ b/struct.go
@@ -316,6 +316,7 @@ func MapToWithMapper(v interface{}, mapper NameMapper, source interface{}, other
 		return err
 	}
 	cfg.NameMapper = mapper
+	cfg.BlockMode = false
 	return cfg.MapTo(v)
 }
 
@@ -327,6 +328,7 @@ func StrictMapToWithMapper(v interface{}, mapper NameMapper, source interface{},
 		return err
 	}
 	cfg.NameMapper = mapper
+	cfg.BlockMode = false
 	return cfg.StrictMapTo(v)
 }
 


### PR DESCRIPTION
你好，我在用ini包时，当直接调用包级别的映射函数（ini.MapTo）时，文件数据只在包内部临时使用一次，所以不会进行写操作。这时候取消锁机制应该更快。