### PR TITLE
Escape delimiters in string slice values

### DIFF
--- a/ini_test.go
+++ b/ini_test.go
@@ -87,6 +87,13 @@ key  = "value"
 key2 = "value2" ; This is a comment for key2
 key3 = "one", "two", "three"
 
+[string escapes]
+key1 = value1, value2, value3
+key2 = value1\, value2
+key3 = val\ue1, value2
+key4 = value1\\, value\\\\2
+key5 = value1\,, value2
+
 [advance]
 value with quotes = "some value"
 value quote2 again = 'some value'
@@ -396,6 +403,13 @@ Good man.
 	; This is a comment for key2
 	key2 = value2
 	key3 = "one", "two", "three"
+
+[string escapes]
+	key1 = value1, value2, value3
+	key2 = value1\, value2
+	key3 = val\ue1, value2
+	key4 = value1\\, value\\\\2
+	key5 = value1\,, value2
 
 [advance]
 	value with quotes      = some value

--- a/ini_test.go
+++ b/ini_test.go
@@ -93,6 +93,7 @@ key2 = value1\, value2
 key3 = val\ue1, value2
 key4 = value1\\, value\\\\2
 key5 = value1\,, value2
+key6 = aaa bbb\ and\ space ccc
 
 [advance]
 value with quotes = "some value"
@@ -410,6 +411,7 @@ Good man.
 	key3 = val\ue1, value2
 	key4 = value1\\, value\\\\2
 	key5 = value1\,, value2
+	key6 = aaa bbb\ and\ space ccc
 
 [advance]
 	value with quotes      = some value

--- a/key.go
+++ b/key.go
@@ -15,6 +15,7 @@
 package ini
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"strconv"
@@ -444,11 +445,39 @@ func (k *Key) Strings(delim string) []string {
 		return []string{}
 	}
 
-	vals := strings.Split(str, delim)
-	for i := range vals {
-		// vals[i] = k.transformValue(strings.TrimSpace(vals[i]))
-		vals[i] = strings.TrimSpace(vals[i])
+	runes := []rune(str)
+	vals := make([]string, 0)
+	idx := 0
+	var buf bytes.Buffer
+	escape := false
+	for {
+		if escape {
+			escape = false
+			if runes[idx] != '\\' && !strings.HasPrefix(string(runes[idx:]), delim) {
+				buf.WriteRune('\\')
+			}
+			buf.WriteRune(runes[idx])
+		} else {
+			if runes[idx] == '\\' {
+				escape = true
+			} else if strings.HasPrefix(string(runes[idx:]), delim) {
+				idx += len(delim) - 1
+				vals = append(vals, strings.TrimSpace(buf.String()))
+				buf.Reset()
+			} else {
+				buf.WriteRune(runes[idx])
+			}
+		}
+		idx += 1
+		if idx == len(runes) {
+			break
+		}
 	}
+
+	if buf.Len() > 0 {
+		vals = append(vals, strings.TrimSpace(buf.String()))
+	}
+
 	return vals
 }
 

--- a/key_test.go
+++ b/key_test.go
@@ -250,6 +250,7 @@ func Test_Key(t *testing.T) {
 			So(sec.Key("key3").Strings(","), ShouldResemble, []string{`val\ue1`, "value2"})
 			So(sec.Key("key4").Strings(","), ShouldResemble, []string{`value1\`, `value\\2`})
 			So(sec.Key("key5").Strings(",,"), ShouldResemble, []string{"value1,, value2"})
+			So(sec.Key("key6").Strings(" "), ShouldResemble, []string{"aaa", "bbb and space", "ccc"})
 		})
 
 		Convey("Get valid values into slice", func() {

--- a/key_test.go
+++ b/key_test.go
@@ -73,7 +73,7 @@ func Test_Key(t *testing.T) {
 
 		Convey("Get sections", func() {
 			sections := cfg.Sections()
-			for i, name := range []string{DEFAULT_SECTION, "author", "package", "package.sub", "features", "types", "array", "note", "comments", "advance"} {
+			for i, name := range []string{DEFAULT_SECTION, "author", "package", "package.sub", "features", "types", "array", "note", "comments", "string escapes", "advance"} {
 				So(sections[i].Name(), ShouldEqual, name)
 			}
 		})
@@ -241,6 +241,15 @@ func Test_Key(t *testing.T) {
 			So(err, ShouldBeNil)
 			vals6 := sec.Key("TIMES").Times(",")
 			timesEqual(vals6, t, t, t)
+		})
+
+		Convey("Test string slice escapes", func() {
+			sec := cfg.Section("string escapes")
+			So(sec.Key("key1").Strings(","), ShouldResemble, []string{"value1", "value2", "value3"})
+			So(sec.Key("key2").Strings(","), ShouldResemble, []string{"value1, value2"})
+			So(sec.Key("key3").Strings(","), ShouldResemble, []string{`val\ue1`, "value2"})
+			So(sec.Key("key4").Strings(","), ShouldResemble, []string{`value1\`, `value\\2`})
+			So(sec.Key("key5").Strings(",,"), ShouldResemble, []string{"value1,, value2"})
 		})
 
 		Convey("Get valid values into slice", func() {

--- a/section_test.go
+++ b/section_test.go
@@ -28,7 +28,7 @@ func Test_Section(t *testing.T) {
 		So(cfg, ShouldNotBeNil)
 
 		Convey("Get section strings", func() {
-			So(strings.Join(cfg.SectionStrings(), ","), ShouldEqual, "DEFAULT,author,package,package.sub,features,types,array,note,comments,advance")
+			So(strings.Join(cfg.SectionStrings(), ","), ShouldEqual, "DEFAULT,author,package,package.sub,features,types,array,note,comments,string escapes,advance")
 		})
 
 		Convey("Delete a section", func() {
@@ -50,7 +50,7 @@ func Test_SectionRaw(t *testing.T) {
 	Convey("Test section raw string", t, func() {
 		cfg, err := LoadSources(
 			LoadOptions{
-				Insensitive: true,
+				Insensitive:         true,
 				UnparseableSections: []string{"core_lesson", "comments"},
 			},
 			"testdata/aicc.ini")


### PR DESCRIPTION
Use backslash to escape delimiters.

Fixes #32 