### PR TITLE
map slices in strict mode too

### DIFF
--- a/struct.go
+++ b/struct.go
@@ -113,8 +113,8 @@ func setSliceWithProperType(key *Key, field reflect.Value, delim string, allowSh
 	default:
 		return fmt.Errorf("unsupported type '[]%s'", sliceOf)
 	}
-	if isStrict {
-		return err
+	if err != nil {
+		return wrapStrictError(err, isStrict)
 	}
 
 	slice := reflect.MakeSlice(field.Type(), numVals, numVals)

--- a/struct_test.go
+++ b/struct_test.go
@@ -244,6 +244,20 @@ age=a30`))
 		So(cfg.Section("").StrictMapTo(s), ShouldNotBeNil)
 	})
 
+	Convey("Map slice in strict mode", t, func() {
+		cfg, err := Load([]byte(`
+names=alice, bruce`))
+		So(err, ShouldBeNil)
+
+		type Strict struct {
+			Names []string `ini:"names"`
+		}
+		s := new(Strict)
+
+		So(cfg.Section("").StrictMapTo(s), ShouldBeNil)
+		So(fmt.Sprint(s.Names), ShouldEqual, "[alice bruce]")
+	})
+
 	Convey("Reflect from struct", t, func() {
 		type Embeded struct {
 			Dates       []time.Time `delim:"|"`


### PR DESCRIPTION
Hi,

If I map a section to a struct with StrictMapTo instead of MapTo then fields with slice type are not mapped due to an 'if isStrict { return err}' construct in setSliceWithProperType. 
The PR is correcting this.

-ptr-