### PR TITLE
Fix integer overflow

### DIFF
--- a/struct.go
+++ b/struct.go
@@ -166,7 +166,7 @@ func setWithProperType(t reflect.Type, key *Key, field reflect.Value, delim stri
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		durationVal, err := key.Duration()
 		// Skip zero value
-		if err == nil && int(durationVal) > 0 {
+		if err == nil && int64(durationVal) > 0 {
 			field.Set(reflect.ValueOf(durationVal))
 			return nil
 		}

--- a/struct_test.go
+++ b/struct_test.go
@@ -370,3 +370,18 @@ func Test_NameGetter(t *testing.T) {
 		So(tg.PackageName, ShouldEqual, "ini")
 	})
 }
+
+type testDurationStruct struct {
+	Duration time.Duration `ini:"Duration"`
+}
+
+func Test_Duration(t *testing.T) {
+	Convey("Duration less than 16m50s", t, func() {
+		ds := new(testDurationStruct)
+		So(ini.MapTo(ds, []byte("Duration=16m49s")), ShouldBeNil)
+
+		dur, err := time.ParseDuration("16m49s")
+		So(err, ShouldBeNil)
+		So(ds.Duration.Seconds(), ShouldEqual, dur.Seconds())
+	})
+}


### PR DESCRIPTION
### What problem should be fixed?

time.Duration conversion in 32 bits systems. If duration is less than 16m50s the conversion will fail.

### Have you added test cases to catch the problem?

Yes