### PR TITLE
Keys should not consider themself for transformation.

### DIFF
--- a/key.go
+++ b/key.go
@@ -114,7 +114,7 @@ func (k *Key) transformValue(val string) string {
 
 		// Search in the same section.
 		nk, err := k.s.GetKey(noption)
-		if err != nil {
+		if err != nil || k == nk {
 			// Search again in default section.
 			nk, _ = k.s.f.Section("").GetKey(noption)
 		}


### PR DESCRIPTION
### What problem should be fixed?

NAME = ini
[package]
NAME = $(NAME)

I believe NAME in section [package] should evaluate to ini

### Have you added test cases to catch the problem?

nope :/
