### PR TITLE
Add Support for spaces around '=' w/o PrettyFormat

### DIFF
--- a/file.go
+++ b/file.go
@@ -228,7 +228,7 @@ func (f *File) Append(source interface{}, others ...interface{}) error {
 
 func (f *File) writeToBuffer(indent string) (*bytes.Buffer, error) {
 	equalSign := "="
-	if PrettyFormat {
+	if PrettyFormat || PrettyEqual {
 		equalSign = " = "
 	}
 

--- a/ini.go
+++ b/ini.go
@@ -53,6 +53,9 @@ var (
 	// or reduce all possible spaces for compact format.
 	PrettyFormat = true
 
+	// Place spaces around "=" sign even when PrettyFormat is false
+	PrettyEqual = false
+
 	// Explicitly write DEFAULT section header
 	DefaultHeader = false
 


### PR DESCRIPTION
The default git config format is equivalent to PrettyFormat w/o
alignment (i.e. just spaces around '=') and SaveToIndent(..., "\t")

This patch allows for setting PrettyFormat=false and PrettySpaces=True
to achieve the same output as the git config default.

It is backwards compatible in that current use case output will not be
affected unless you specifically disable PrettyFormat AND enable
PrettySpaces.

### What problem should be fixed?

### Have you added test cases to catch the problem?
