### PR TITLE
Support *struct type in struct field.

### DIFF
--- a/struct.go
+++ b/struct.go
@@ -244,7 +244,7 @@ func (s *Section) mapTo(val reflect.Value, isStrict bool) error {
 			continue
 		}
 
-		isAnonymous := tpField.Type.Kind() == reflect.Ptr && tpField.Anonymous
+		isAnonymous := tpField.Type.Kind() == reflect.Ptr && (tpField.Anonymous || tpField.Type.Elem().Kind() == reflect.Struct)
 		isStruct := tpField.Type.Kind() == reflect.Struct
 		if isAnonymous {
 			field.Set(reflect.New(tpField.Type.Elem()))


### PR DESCRIPTION
```ini
[a]
s = "test"
```

```go
type A struct {
  S string `ini:"s"`
}
type B struct {
  A *A `ini:a`
}
```

before: It's an error returned.
after: Successfully parsed the ini file.