### PR TITLE
fix empty key when call section.Key

### DIFF
--- a/section.go
+++ b/section.go
@@ -171,7 +171,11 @@ func (s *Section) Key(name string) *Key {
 	if err != nil {
 		// It's OK here because the only possible error is empty key name,
 		// but if it's empty, this piece of code won't be executed.
-		key, _ = s.NewKey(name, "")
+		key, err = s.NewKey(name, "")
+		if err != nil {
+			// assert err != nil
+			panic(err)
+		}
 		return key
 	}
 	return key


### PR DESCRIPTION
### What problem should be fixed?
Add assert code when key is empty.

### Have you added test cases to catch the problem?

```go
package ini 

import (
    "testing"

    "github.com/go-ini/ini"
)

func TestEtc(t *testing.T) {
    f := ini.Empty()
    if f.Section("").Key("").String() != "" {
        t.Fatal("need empty data")
    } 
}
```