### PR TITLE
ini: strip leading & trailing quotes from multi-line values

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -185,6 +185,11 @@ func (p *parser) readContinuationLines(val string) (string, error) {
 		}
 		val = val[:len(val)-1]
 	}
+	// Trim single and double quotes
+	if hasSurroundedQuote(val, '\'') ||
+		hasSurroundedQuote(val, '"') {
+		val = val[1 : len(val)-1]
+	}
 	return val, nil
 }
 


### PR DESCRIPTION
Stripping currently only occurs for single line values. Handle
multi-line too.

Signed-off-by: David Disseldorp <ddiss@suse.de>