### PR TITLE
section: update keysHash in DeleteKey

### DIFF
--- a/section.go
+++ b/section.go
@@ -238,6 +238,7 @@ func (s *Section) DeleteKey(name string) {
 		if k == name {
 			s.keyList = append(s.keyList[:i], s.keyList[i+1:]...)
 			delete(s.keys, name)
+			delete(s.keysHash, name)
 			return
 		}
 	}


### PR DESCRIPTION
### What problem should be fixed?

Section's `DeleteKey()` method does not update the internal hash map.

### Have you added test cases to catch the problem?

No, wasn't sure whether to add it to `KeyHash`, `DeleteKey`, or as a separate test. Current behavior:

```go
package main

import (
	"fmt"

	"github.com/go-ini/ini"
)

func main() {
	s := ini.Empty().Section("")

	s.Key("key").SetValue("value")
	fmt.Println("keys:", s.KeyStrings())
	fmt.Println("hash:", s.KeysHash())

	s.DeleteKey("key")
	fmt.Println("keys:", s.KeyStrings())
	fmt.Println("hash:", s.KeysHash())
}
```

Output:
```
keys: [key]
hash: map[key:value]
keys: []
hash: map[key:value]
```