### PR TITLE
parse hex number

### DIFF
--- a/key.go
+++ b/key.go
@@ -667,7 +667,8 @@ func (k *Key) parseFloat64s(strs []string, addInvalid, returnOnInvalid bool) ([]
 func (k *Key) parseInts(strs []string, addInvalid, returnOnInvalid bool) ([]int, error) {
 	vals := make([]int, 0, len(strs))
 	for _, str := range strs {
-		val, err := strconv.Atoi(str)
+		val_i64, err := strconv.ParseInt(str, 0, 64)
+		val := int(val_i64)        
 		if err != nil && returnOnInvalid {
 			return nil, err
 		}

--- a/key.go
+++ b/key.go
@@ -191,18 +191,18 @@ func (k *Key) Int() (int, error) {
 
 // Int64 returns int64 type value.
 func (k *Key) Int64() (int64, error) {
-	return strconv.ParseInt(k.String(), 10, 64)
+	return strconv.ParseInt(k.String(), 0, 64)
 }
 
 // Uint returns uint type valued.
 func (k *Key) Uint() (uint, error) {
-	u, e := strconv.ParseUint(k.String(), 10, 64)
+	u, e := strconv.ParseUint(k.String(), 0, 64)
 	return uint(u), e
 }
 
 // Uint64 returns uint64 type value.
 func (k *Key) Uint64() (uint64, error) {
-	return strconv.ParseUint(k.String(), 10, 64)
+	return strconv.ParseUint(k.String(), 0, 64)
 }
 
 // Duration returns time.Duration type value.
@@ -682,7 +682,7 @@ func (k *Key) parseInts(strs []string, addInvalid, returnOnInvalid bool) ([]int,
 func (k *Key) parseInt64s(strs []string, addInvalid, returnOnInvalid bool) ([]int64, error) {
 	vals := make([]int64, 0, len(strs))
 	for _, str := range strs {
-		val, err := strconv.ParseInt(str, 10, 64)
+		val, err := strconv.ParseInt(str, 0, 64)
 		if err != nil && returnOnInvalid {
 			return nil, err
 		}
@@ -697,7 +697,7 @@ func (k *Key) parseInt64s(strs []string, addInvalid, returnOnInvalid bool) ([]in
 func (k *Key) parseUints(strs []string, addInvalid, returnOnInvalid bool) ([]uint, error) {
 	vals := make([]uint, 0, len(strs))
 	for _, str := range strs {
-		val, err := strconv.ParseUint(str, 10, 0)
+		val, err := strconv.ParseUint(str, 0, 0)
 		if err != nil && returnOnInvalid {
 			return nil, err
 		}
@@ -712,7 +712,7 @@ func (k *Key) parseUints(strs []string, addInvalid, returnOnInvalid bool) ([]uin
 func (k *Key) parseUint64s(strs []string, addInvalid, returnOnInvalid bool) ([]uint64, error) {
 	vals := make([]uint64, 0, len(strs))
 	for _, str := range strs {
-		val, err := strconv.ParseUint(str, 10, 64)
+		val, err := strconv.ParseUint(str, 0, 64)
 		if err != nil && returnOnInvalid {
 			return nil, err
 		}

--- a/key.go
+++ b/key.go
@@ -186,7 +186,8 @@ func (k *Key) Float64() (float64, error) {
 
 // Int returns int type value.
 func (k *Key) Int() (int, error) {
-	return strconv.Atoi(k.String())
+    v, err := strconv.ParseInt(k.String(), 0, 64)
+    return int(v), err
 }
 
 // Int64 returns int64 type value.

--- a/key.go
+++ b/key.go
@@ -668,8 +668,8 @@ func (k *Key) parseFloat64s(strs []string, addInvalid, returnOnInvalid bool) ([]
 func (k *Key) parseInts(strs []string, addInvalid, returnOnInvalid bool) ([]int, error) {
 	vals := make([]int, 0, len(strs))
 	for _, str := range strs {
-		val_i64, err := strconv.ParseInt(str, 0, 64)
-		val := int(val_i64)        
+		valInt64, err := strconv.ParseInt(str, 0, 64)
+		val := int(valInt64)        
 		if err != nil && returnOnInvalid {
 			return nil, err
 		}

--- a/key_test.go
+++ b/key_test.go
@@ -216,6 +216,10 @@ func TestKey_Helpers(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(v7.String(), ShouldEqual, t.String())
 
+			v8, err := sec.Key("HEXNUMBER").Int()
+			So(err, ShouldBeNil)
+			So(v8, ShouldEqual, 0x3000)
+
 			Convey("Must get values with type", func() {
 				So(sec.Key("STRING").MustString("404"), ShouldEqual, "str")
 				So(sec.Key("BOOL").MustBool(), ShouldBeTrue)
@@ -225,6 +229,7 @@ func TestKey_Helpers(t *testing.T) {
 				So(sec.Key("UINT").MustUint(), ShouldEqual, 3)
 				So(sec.Key("UINT").MustUint64(), ShouldEqual, 3)
 				So(sec.Key("TIME").MustTime().String(), ShouldEqual, t.String())
+				So(sec.Key("HEXNUMBER").MustInt(), ShouldEqual, 0x3000)
 
 				dur, err := time.ParseDuration("2h45m")
 				So(err, ShouldBeNil)
@@ -238,6 +243,7 @@ func TestKey_Helpers(t *testing.T) {
 					So(sec.Key("INT64_404").MustInt64(15), ShouldEqual, 15)
 					So(sec.Key("UINT_404").MustUint(6), ShouldEqual, 6)
 					So(sec.Key("UINT64_404").MustUint64(6), ShouldEqual, 6)
+					So(sec.Key("HEXNUMBER_404").MustInt(0x3001), ShouldEqual, 0x3001)
 
 					t, err := time.Parse(time.RFC3339, "2014-01-01T20:17:05Z")
 					So(err, ShouldBeNil)
@@ -255,6 +261,7 @@ func TestKey_Helpers(t *testing.T) {
 						So(sec.Key("UINT64_404").String(), ShouldEqual, "6")
 						So(sec.Key("TIME_404").String(), ShouldEqual, "2014-01-01T20:17:05Z")
 						So(sec.Key("DURATION_404").String(), ShouldEqual, "2h45m0s")
+						So(sec.Key("HEXNUMBER_404").String(), ShouldEqual, "12289")
 					})
 				})
 			})
@@ -522,38 +529,5 @@ expires = %(expires)s`))
 		So(f, ShouldNotBeNil)
 		So(f.Section("package").Key("NAME").String(), ShouldEqual, "ini")
 		So(f.Section("package").Key("expires").String(), ShouldEqual, "yes")
-	})
-}
-
-func TestParseHexNumber(t *testing.T) {
-	Convey("Parse hex number", t, func(){
-		f, err := ini.Load([]byte(`
-[Meter]
-addr1 = 0x3000
-addr2 = 3000
-`))
-		So(err, ShouldBeNil)
-		So(f, ShouldNotBeNil)
-		
-		addr1, err := f.Section("Meter").Key("addr1").Int()
-		So(err, ShouldBeNil)
-		So(addr1, ShouldEqual, 0x3000)
-
-		addr2, err := f.Section("Meter").Key("addr2").Int()
-		So(err, ShouldBeNil)
-		So(addr2, ShouldEqual, 3000)
-
-		type Meter struct{
-			Addr1 int `ini:"addr1"`
-			Addr2 int `ini:"addr2"`	
-		}
-		ini_cfg := struct{
-			Meter Meter
-		}{}
-
-		err = f.MapTo(&ini_cfg)
-		So(err, ShouldBeNil)
-		So(ini_cfg.Meter.Addr1, ShouldEqual, 0x3000)
-		So(ini_cfg.Meter.Addr2, ShouldEqual, 3000)
 	})
 }

--- a/key_test.go
+++ b/key_test.go
@@ -216,7 +216,7 @@ func TestKey_Helpers(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(v7.String(), ShouldEqual, t.String())
 
-			v8, err := sec.Key("HEXNUMBER").Int()
+			v8, err := sec.Key("HEX_NUMBER").Int()
 			So(err, ShouldBeNil)
 			So(v8, ShouldEqual, 0x3000)
 
@@ -229,7 +229,7 @@ func TestKey_Helpers(t *testing.T) {
 				So(sec.Key("UINT").MustUint(), ShouldEqual, 3)
 				So(sec.Key("UINT").MustUint64(), ShouldEqual, 3)
 				So(sec.Key("TIME").MustTime().String(), ShouldEqual, t.String())
-				So(sec.Key("HEXNUMBER").MustInt(), ShouldEqual, 0x3000)
+				So(sec.Key("HEX_NUMBER").MustInt(), ShouldEqual, 0x3000)
 
 				dur, err := time.ParseDuration("2h45m")
 				So(err, ShouldBeNil)
@@ -243,7 +243,7 @@ func TestKey_Helpers(t *testing.T) {
 					So(sec.Key("INT64_404").MustInt64(15), ShouldEqual, 15)
 					So(sec.Key("UINT_404").MustUint(6), ShouldEqual, 6)
 					So(sec.Key("UINT64_404").MustUint64(6), ShouldEqual, 6)
-					So(sec.Key("HEXNUMBER_404").MustInt(0x3001), ShouldEqual, 0x3001)
+					So(sec.Key("HEX_NUMBER_404").MustInt(0x3001), ShouldEqual, 0x3001)
 
 					t, err := time.Parse(time.RFC3339, "2014-01-01T20:17:05Z")
 					So(err, ShouldBeNil)
@@ -261,7 +261,7 @@ func TestKey_Helpers(t *testing.T) {
 						So(sec.Key("UINT64_404").String(), ShouldEqual, "6")
 						So(sec.Key("TIME_404").String(), ShouldEqual, "2014-01-01T20:17:05Z")
 						So(sec.Key("DURATION_404").String(), ShouldEqual, "2h45m0s")
-						So(sec.Key("HEXNUMBER_404").String(), ShouldEqual, "12289")
+						So(sec.Key("HEX_NUMBER_404").String(), ShouldEqual, "12289")
 					})
 				})
 			})

--- a/key_test.go
+++ b/key_test.go
@@ -524,3 +524,36 @@ expires = %(expires)s`))
 		So(f.Section("package").Key("expires").String(), ShouldEqual, "yes")
 	})
 }
+
+func TestParseHexNumber(t *testing.T) {
+	Convey("Parse hex number", t, func(){
+		f, err := ini.Load([]byte(`
+[Meter]
+addr1 = 0x3000
+addr2 = 3000
+`))
+		So(err, ShouldBeNil)
+		So(f, ShouldNotBeNil)
+		
+		addr1, err := f.Section("Meter").Key("addr1").Int()
+		So(err, ShouldBeNil)
+		So(addr1, ShouldEqual, 0x3000)
+
+		addr2, err := f.Section("Meter").Key("addr2").Int()
+		So(err, ShouldBeNil)
+		So(addr2, ShouldEqual, 3000)
+
+		type Meter struct{
+			Addr1 int `ini:"addr1"`
+			Addr2 int `ini:"addr2"`	
+		}
+		ini_cfg := struct{
+			Meter Meter
+		}{}
+
+		err = f.MapTo(&ini_cfg)
+		So(err, ShouldBeNil)
+		So(ini_cfg.Meter.Addr1, ShouldEqual, 0x3000)
+		So(ini_cfg.Meter.Addr2, ShouldEqual, 3000)
+	})
+}

--- a/testdata/TestFile_WriteTo.golden
+++ b/testdata/TestFile_WriteTo.golden
@@ -38,6 +38,7 @@ INT        = 10
 TIME       = 2015-01-01T20:17:05Z
 DURATION   = 2h45m
 UINT       = 3
+HEXNUMBER  = 0x3000
 
 [array]
 STRINGS  = en, zh, de

--- a/testdata/TestFile_WriteTo.golden
+++ b/testdata/TestFile_WriteTo.golden
@@ -38,7 +38,7 @@ INT        = 10
 TIME       = 2015-01-01T20:17:05Z
 DURATION   = 2h45m
 UINT       = 3
-HEXNUMBER  = 0x3000
+HEX_NUMBER = 0x3000
 
 [array]
 STRINGS  = en, zh, de

--- a/testdata/full.ini
+++ b/testdata/full.ini
@@ -36,6 +36,7 @@ INT        = 10
 TIME       = 2015-01-01T20:17:05Z
 DURATION   = 2h45m
 UINT       = 3
+HEXNUMBER  = 0x3000
 
 [array]
 STRINGS  = en, zh, de

--- a/testdata/full.ini
+++ b/testdata/full.ini
@@ -36,7 +36,7 @@ INT        = 10
 TIME       = 2015-01-01T20:17:05Z
 DURATION   = 2h45m
 UINT       = 3
-HEXNUMBER  = 0x3000
+HEX_NUMBER = 0x3000
 
 [array]
 STRINGS  = en, zh, de


### PR DESCRIPTION
### What problem should be fixed?
parse hex number on map to struct, for example: 
ini file:
```ini
[Meter]
addr = 0x3000
```

map to:
```golang
type Meter struct{
    Addr int `ini:"addr"`
}
```

### Have you added test cases to catch the problem?
