### PR TITLE
struct: map into fields that are struct pointers

### DIFF
--- a/struct_test.go
+++ b/struct_test.go
@@ -49,6 +49,8 @@ type testStruct struct {
 	Born         time.Time
 	Time         time.Duration `ini:"Duration"`
 	Others       testNested
+	OthersPtr    *testNested
+	NilPtr       *testNested
 	*TestEmbeded `ini:"grade"`
 	Unused       int `ini:"-"`
 	Unsigned     uint
@@ -70,6 +72,16 @@ Shadows = 1, 2
 Shadows = 3, 4
 
 [Others]
+Cities = HangZhou|Boston
+Visits = 1993-10-07T20:17:05Z, 1993-10-07T20:17:05Z
+Years = 1993,1994
+Numbers = 10010,10086
+Ages = 18,19
+Populations = 12345678,98765432
+Coordinates = 192.168,10.11
+Note = Hello world!
+
+[OthersPtr]
 Cities = HangZhou|Boston
 Visits = 1993-10-07T20:17:05Z, 1993-10-07T20:17:05Z
 Years = 1993,1994
@@ -156,6 +168,17 @@ func Test_MapToStruct(t *testing.T) {
 			So(fmt.Sprint(ts.Others.Coordinates), ShouldEqual, "[192.168 10.11]")
 			So(ts.Others.Note, ShouldEqual, "Hello world!")
 			So(ts.TestEmbeded.GPA, ShouldEqual, 2.8)
+
+			So(strings.Join(ts.OthersPtr.Cities, ","), ShouldEqual, "HangZhou,Boston")
+			So(ts.OthersPtr.Visits[0].String(), ShouldEqual, t.String())
+			So(fmt.Sprint(ts.OthersPtr.Years), ShouldEqual, "[1993 1994]")
+			So(fmt.Sprint(ts.OthersPtr.Numbers), ShouldEqual, "[10010 10086]")
+			So(fmt.Sprint(ts.OthersPtr.Ages), ShouldEqual, "[18 19]")
+			So(fmt.Sprint(ts.OthersPtr.Populations), ShouldEqual, "[12345678 98765432]")
+			So(fmt.Sprint(ts.OthersPtr.Coordinates), ShouldEqual, "[192.168 10.11]")
+			So(ts.OthersPtr.Note, ShouldEqual, "Hello world!")
+
+			So(ts.NilPtr, ShouldBeNil)
 		})
 
 		Convey("Map section to struct", func() {


### PR DESCRIPTION
### What problem should be fixed?

Allow 'mapTo' to load into fields that are struct pointers iff there is
a section for that field and fieldname. The field is initialised to
pointer type and then the data is loaded.

### Have you added test cases to catch the problem?

Yes.
