### PR TITLE
support Python multi-line values with empty first line

### DIFF
--- a/ini_test.go
+++ b/ini_test.go
@@ -507,11 +507,16 @@ long_rsa_private_key = -----BEGIN RSA PRIVATE KEY-----
   foobar
   barfoo
   -----END RSA PRIVATE KEY-----
+multiline_list =
+  first
+  second
+  third
 `))
 				So(err, ShouldBeNil)
 				So(f, ShouldNotBeNil)
 
 				So(f.Section("long").Key("long_rsa_private_key").String(), ShouldEqual, "-----BEGIN RSA PRIVATE KEY-----\nfoo\nbar\nfoobar\nbarfoo\n-----END RSA PRIVATE KEY-----")
+				So(f.Section("long").Key("multiline_list").String(), ShouldEqual, "\nfirst\nsecond\nthird")
 			})
 
 			Convey("Can parse big python-compatible INI files", func() {


### PR DESCRIPTION
### What problem should be fixed?
Multline line values whose initial line was empty were not parsed. This style of list is commonly used in a couple of places, but the main one I've found is LLVMBuild.txt (an ini-style build configuration used by LLVM).

### Have you added test cases to catch the problem?
Yes