### PR TITLE
parsing large Python-style multiline values

### DIFF
--- a/ini.go
+++ b/ini.go
@@ -29,7 +29,7 @@ const (
 
 	// Maximum allowed depth when recursively substituing variable names.
 	depthValues = 99
-	version     = "1.48.0"
+	version     = "1.48.0-1"
 )
 
 // Version returns current package version literal.
@@ -111,6 +111,10 @@ type LoadOptions struct {
 	KeyValueDelimiters string
 	// PreserveSurroundedQuote indicates whether to preserve surrounded quote (single and double quotes).
 	PreserveSurroundedQuote bool
+	// turn on debug output (currently only useful to debug parsing Python-style multiline values)
+	Debug bool
+	// increase reader buffer size
+	ReaderBufferSize int
 }
 
 // LoadSources allows caller to apply customized options for loading from data source(s).

--- a/ini_multiline_value_fix_test.go
+++ b/ini_multiline_value_fix_test.go
@@ -1,7 +1,7 @@
 package ini_test
 
 import (
-	"gopkg.in/ini.v1"
+	"github.com/r3db34n/ini"
 	. "github.com/smartystreets/goconvey/convey"
 	"path/filepath"
 	"testing"

--- a/ini_multiline_value_fix_test.go
+++ b/ini_multiline_value_fix_test.go
@@ -1,0 +1,60 @@
+package ini_test
+
+import (
+	"github.com/r3db34n/ini"
+	. "github.com/smartystreets/goconvey/convey"
+	"path/filepath"
+	"testing"
+)
+
+type testData struct {
+	Value1 string `ini:"value1"`
+	Value2 string `ini:"value2"`
+}
+
+func TestMultiline(t *testing.T) {
+	Value1 := "some text here\n"+
+		"some more text here\n"+
+		"\n"+
+		"there is an empty line above and below\n"
+
+	Value2 := "there is an empty line above\n"+
+		"that is not indented so it should not be part\n"+
+		"of the value"
+
+	Convey("Parse Python-style multiline values", t, func() {
+
+		// enable Python-style multiline values
+		opts := ini.LoadOptions{
+			AllowPythonMultilineValues: true,
+		}
+
+		// load test data
+		path := filepath.Join("testdata", "multiline.ini")
+		data, e := ini.LoadSources(opts, path)
+
+		// Should have no error
+		So(e, ShouldBeNil)
+
+		// Should have parsed data
+		So(data, ShouldNotBeNil)
+
+		// Should have only the default section
+		So(len(data.Sections()), ShouldEqual, 1)
+
+		// Should have default section
+		defaultSection := data.Section("")
+		So(defaultSection, ShouldNotBeNil)
+
+		// Default section should map to test data struct
+		var testData testData
+		e = defaultSection.MapTo(&testData)
+		So(e, ShouldBeNil)
+
+		// 'value1' should match expected value
+		So(testData.Value1, ShouldEqual, Value1)
+
+		// 'value2' should match expected value
+		So(testData.Value2, ShouldEqual, Value2)
+	})
+}

--- a/ini_multiline_value_fix_test.go
+++ b/ini_multiline_value_fix_test.go
@@ -1,7 +1,7 @@
 package ini_test
 
 import (
-	"github.com/r3db34n/ini"
+	"gopkg.in/ini.v1"
 	. "github.com/smartystreets/goconvey/convey"
 	"path/filepath"
 	"testing"

--- a/parser.go
+++ b/parser.go
@@ -297,24 +297,29 @@ func (p *parser) readPythonMultilines(line string, bufferSize int) (string, erro
 		peekMatches := pythonMultiline.FindStringSubmatch(string(peekData))
 		// NOTE: Return if not a python-ini multi-line value.
 		if len(peekMatches) < 2 {
+			fmt.Println("peekMatches is only ", len(peekMatches))
 			return line, nil
 		}
 
 		currentIdentSize := len(peekMatches[1])
 		if currentIdentSize <= 0 {
+			fmt.Println("currentIdentSize is ", currentIdentSize)
 			return line, nil
 		}
 
 		// NOTE: Just advance the parser reader (buffer) in-sync with the peek buffer.
 		_, err := p.readUntil('\n')
 		if err != nil {
+			fmt.Println("readUntil() returned error: ", err)
 			return "", err
 		}
 
 		// handle indented empty line
 		if len(peekMatches) < 3 {
+			fmt.Println("got empty line!")
 			line += "\n"
 		} else {
+			fmt.Println("got line: ", peekMatches[2])
 			line += fmt.Sprintf("\n%s", peekMatches[2])
 		}
 	}

--- a/parser.go
+++ b/parser.go
@@ -25,11 +25,7 @@ import (
 	"unicode"
 )
 
-<<<<<<< HEAD
 var pythonMultiline = regexp.MustCompile(`^([\t\f ]+)(.*)`)
-=======
-var pythonMultiline = regexp.MustCompile("^(\\s)([^\n]+)")
->>>>>>> 933ff1d53ca6980c4a07b5b8cdad0f4887a01a6a
 
 type parserOptions struct {
 	IgnoreContinuation          bool

--- a/parser.go
+++ b/parser.go
@@ -25,6 +25,7 @@ import (
 	"unicode"
 )
 
+const minReaderBufferSize = 64*1024
 var pythonMultiline = regexp.MustCompile(`^([\t\f ]+)(.*)`)
 
 type parserOptions struct {
@@ -35,6 +36,8 @@ type parserOptions struct {
 	UnescapeValueDoubleQuotes   bool
 	UnescapeValueCommentSymbols bool
 	PreserveSurroundedQuote     bool
+	Debug 						bool
+	ReaderBufferSize			int
 }
 
 type parser struct {
@@ -47,8 +50,13 @@ type parser struct {
 }
 
 func newParser(r io.Reader, opts parserOptions) *parser {
+	size := opts.ReaderBufferSize
+	if size < minReaderBufferSize {
+		size = minReaderBufferSize
+	}
+
 	return &parser{
-		buf:     bufio.NewReader(r),
+		buf:     bufio.NewReaderSize(r, size),
 		options: opts,
 		count:   1,
 		comment: &bytes.Buffer{},
@@ -290,14 +298,37 @@ func (p *parser) readPythonMultilines(line string, bufferSize int) (string, erro
 		peekData, peekErr := peekBuffer.ReadBytes('\n')
 		if peekErr != nil {
 			if peekErr == io.EOF {
+				if p.options.Debug {
+					fmt.Println("readPythonMultilines: failed to peek")
+					fmt.Println("readPythonMultilines: peekData is: '"+string(peekData)+"'")
+					fmt.Println("readPythonMultilines: value is: '"+line+"'")
+				}
 				return line, nil
+			}
+			if p.options.Debug {
+				fmt.Println("readPythonMultilines: failed to peek, returning error")
 			}
 			return "", peekErr
 		}
 
+		if p.options.Debug {
+			fmt.Println("readPythonMultilines: parsing '"+string(peekData)+"'")
+		}
+
 		peekMatches := pythonMultiline.FindStringSubmatch(string(peekData))
-		// NOTE: Return if not a python-ini multi-line value.
+		if p.options.Debug {
+			fmt.Println("readPythonMultilines: matched ", len(peekMatches), " parts:")
+			for n, v := range peekMatches {
+				fmt.Println("   ", n, ": '", v, "'")
+			}
+		}
+
+		// return if not a python-ini multi-line value.
 		if len(peekMatches) != 3 {
+			if p.options.Debug {
+				fmt.Println("readPythonMultilines: didn't match enough parts, meaning the value has ended")
+				fmt.Println("readPythonMultilines: value is: '"+line+"'")
+			}
 			return line, nil
 		}
 
@@ -305,16 +336,28 @@ func (p *parser) readPythonMultilines(line string, bufferSize int) (string, erro
 		currentIndentSize := len(peekMatches[1])
 		if indentSize < 1 {
 			indentSize = currentIndentSize
+			if p.options.Debug {
+				fmt.Println("readPythonMultilines: new indent size is ", indentSize)
+			}
 		}
 
 		// make sure each line is indented at least as far as first line
 		if currentIndentSize < indentSize {
+			if p.options.Debug {
+				fmt.Println("readPythonMultilines: expected indent size is ", indentSize)
+				fmt.Println("readPythonMultilines: current indent size is ", currentIndentSize)
+				fmt.Println("readPythonMultilines: current line is not indented enough to be part of this value")
+				fmt.Println("readPythonMultilines: value is: '"+line+"'")
+			}
 			return line, nil
 		}
 
-		// NOTE: Just advance the parser reader (buffer) in-sync with the peek buffer.
-		_, err := p.readUntil('\n')
+		// advance the parser reader (buffer) in-sync with the peek buffer.
+		_, err := p.buf.Discard(len(peekData))
 		if err != nil {
+			if p.options.Debug {
+				fmt.Println("readPythonMultilines: failed to skip to the end, returning error")
+			}
 			return "", err
 		}
 
@@ -333,6 +376,8 @@ func (f *File) parse(reader io.Reader) (err error) {
 		UnescapeValueDoubleQuotes:   f.options.UnescapeValueDoubleQuotes,
 		UnescapeValueCommentSymbols: f.options.UnescapeValueCommentSymbols,
 		PreserveSurroundedQuote:     f.options.PreserveSurroundedQuote,
+		Debug:     					 f.options.Debug,
+		ReaderBufferSize:			 f.options.ReaderBufferSize,
 	})
 	if err = p.BOM(); err != nil {
 		return fmt.Errorf("BOM: %v", err)
@@ -356,8 +401,8 @@ func (f *File) parse(reader io.Reader) (err error) {
 	// the size of the parser buffer is found.
 	// TODO(unknwon): When Golang 1.10 is the lowest version supported, replace with `parserBufferSize := p.buf.Size()`.
 	parserBufferSize := 0
-	// NOTE: Peek 1kb at a time.
-	currentPeekSize := 1024
+	// NOTE: Peek 40kb at a time.
+	currentPeekSize := minReaderBufferSize
 
 	if f.options.AllowPythonMultilineValues {
 		for {

--- a/parser.go
+++ b/parser.go
@@ -25,7 +25,7 @@ import (
 	"unicode"
 )
 
-var pythonMultiline = regexp.MustCompile("^(\\s+)([^\n]+)")
+var pythonMultiline = regexp.MustCompile("^(\\s+)([^\n]*)")
 
 type parserOptions struct {
 	IgnoreContinuation          bool

--- a/parser.go
+++ b/parser.go
@@ -25,7 +25,7 @@ import (
 	"unicode"
 )
 
-var pythonMultiline = regexp.MustCompile("^(\\s)([^\n]*)")
+var pythonMultiline = regexp.MustCompile("^(\\s)([^\n]+)")
 
 type parserOptions struct {
 	IgnoreContinuation          bool

--- a/parser.go
+++ b/parser.go
@@ -295,11 +295,11 @@ func (p *parser) readPythonMultilines(line string, bufferSize int) (string, erro
 		}
 
 		peekMatches := pythonMultiline.FindStringSubmatch(string(peekData))
-		if len(peekMatches) != 3 {
+		// NOTE: Return if not a python-ini multi-line value.
+		if len(peekMatches) < 2 {
 			return line, nil
 		}
 
-		// NOTE: Return if not a python-ini multi-line value.
 		currentIdentSize := len(peekMatches[1])
 		if currentIdentSize <= 0 {
 			return line, nil
@@ -311,7 +311,12 @@ func (p *parser) readPythonMultilines(line string, bufferSize int) (string, erro
 			return "", err
 		}
 
-		line += fmt.Sprintf("\n%s", peekMatches[2])
+		// handle indented empty line
+		if len(peekMatches) < 3 {
+			line += "\n"
+		} else {
+			line += fmt.Sprintf("\n%s", peekMatches[2])
+		}
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -25,7 +25,11 @@ import (
 	"unicode"
 )
 
+<<<<<<< HEAD
+var pythonMultiline = regexp.MustCompile(`^([\t\f ]+)(.*)`)
+=======
 var pythonMultiline = regexp.MustCompile("^(\\s)([^\n]+)")
+>>>>>>> 933ff1d53ca6980c4a07b5b8cdad0f4887a01a6a
 
 type parserOptions struct {
 	IgnoreContinuation          bool
@@ -297,8 +301,7 @@ func (p *parser) readPythonMultilines(line string, bufferSize int) (string, erro
 
 		peekMatches := pythonMultiline.FindStringSubmatch(string(peekData))
 		// NOTE: Return if not a python-ini multi-line value.
-		if len(peekMatches) < 2 {
-			fmt.Println("peekMatches is only ", len(peekMatches))
+		if len(peekMatches) != 3 {
 			return line, nil
 		}
 
@@ -306,31 +309,21 @@ func (p *parser) readPythonMultilines(line string, bufferSize int) (string, erro
 		currentIndentSize := len(peekMatches[1])
 		if indentSize < 1 {
 			indentSize = currentIndentSize
-			fmt.Println("identSize is ", indentSize)
 		}
 
 		// make sure each line is indented at least as far as first line
 		if currentIndentSize < indentSize {
-			fmt.Println("currentIdentSize is ", currentIndentSize)
 			return line, nil
 		}
 
 		// NOTE: Just advance the parser reader (buffer) in-sync with the peek buffer.
 		_, err := p.readUntil('\n')
 		if err != nil {
-			fmt.Println("readUntil() returned error: ", err)
 			return "", err
 		}
 
 		// handle indented empty line
-		prefix := peekMatches[1][indentSize:]
-		if len(peekMatches) < 3 {
-			fmt.Println("got empty line!")
-			line += "\n" + prefix
-		} else {
-			fmt.Println("got line: ", peekMatches[2])
-			line += "\n" + prefix + peekMatches[2]
-		}
+		line += "\n" + peekMatches[1][indentSize:] + peekMatches[2]
 	}
 }
 

--- a/testdata/multiline.ini
+++ b/testdata/multiline.ini
@@ -1,0 +1,9 @@
+value1 = some text here
+	some more text here
+	
+	there is an empty line above and below
+	
+
+value2 = there is an empty line above
+	that is not indented so it should not be part
+	of the value


### PR DESCRIPTION
### What problem should be fixed?
This change 
- fixes issue #205 
- supports large values (>4kB, defaults to 64kB)
- allows to configure the maximum supported value size
- allows to turn on debug output to figure out why a multiline value does not parse correctly

### Have you added test cases to catch the problem?
There is a new test file with test cases as well as a test data file to cover empty lines in Python-style multiline values.