### PR TITLE
Migrate to Go modules

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -17,7 +17,7 @@ package ini_test
 import (
 	"testing"
 
-	"gopkg.in/ini.v1"
+	"github.com/go-ini/ini"
 )
 
 func newTestFile(block bool) *ini.File {

--- a/file_test.go
+++ b/file_test.go
@@ -19,8 +19,9 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/go-ini/ini"
+
 	. "github.com/smartystreets/goconvey/convey"
-	"gopkg.in/ini.v1"
 )
 
 func TestEmpty(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/go-ini/ini
+
+go 1.13
+
+require github.com/smartystreets/goconvey v1.6.4

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
+github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
+github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/ini_python_multiline_test.go
+++ b/ini_python_multiline_test.go
@@ -4,7 +4,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"gopkg.in/ini.v1"
+	"github.com/go-ini/ini"
+
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -19,12 +20,12 @@ func TestMultiline(t *testing.T) {
 		path := filepath.Join("testdata", "multiline.ini")
 		f, err := ini.LoadSources(ini.LoadOptions{
 			AllowPythonMultilineValues: true,
-			ReaderBufferSize: 64*1024,
+			ReaderBufferSize:           64 * 1024,
 			/*
-			Debug: func(m string) {
-				fmt.Println(m)
-			},
-			 */
+				Debug: func(m string) {
+					fmt.Println(m)
+				},
+			*/
 		}, path)
 		So(err, ShouldBeNil)
 		So(f, ShouldNotBeNil)

--- a/ini_test.go
+++ b/ini_test.go
@@ -20,8 +20,9 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/go-ini/ini"
+
 	. "github.com/smartystreets/goconvey/convey"
-	"gopkg.in/ini.v1"
 )
 
 const (

--- a/key_test.go
+++ b/key_test.go
@@ -21,8 +21,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-ini/ini"
+
 	. "github.com/smartystreets/goconvey/convey"
-	"gopkg.in/ini.v1"
 )
 
 func TestKey_AddShadow(t *testing.T) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -17,8 +17,9 @@ package ini_test
 import (
 	"testing"
 
+	"github.com/go-ini/ini"
+
 	. "github.com/smartystreets/goconvey/convey"
-	"gopkg.in/ini.v1"
 )
 
 func TestBOM(t *testing.T) {

--- a/section_test.go
+++ b/section_test.go
@@ -17,8 +17,9 @@ package ini_test
 import (
 	"testing"
 
+	"github.com/go-ini/ini"
+
 	. "github.com/smartystreets/goconvey/convey"
-	"gopkg.in/ini.v1"
 )
 
 func TestSection_SetBody(t *testing.T) {

--- a/struct_test.go
+++ b/struct_test.go
@@ -21,8 +21,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-ini/ini"
+
 	. "github.com/smartystreets/goconvey/convey"
-	"gopkg.in/ini.v1"
 )
 
 type testNested struct {


### PR DESCRIPTION
### What problem should be fixed?
Importing this package requires a dependency on `gopkg.ini` and currently lacks a `go.mod` file to highlight its dependency on `goconvey`

