### PR TITLE
file: customize output delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Package ini provides INI file read and write functionality in Go.
 
 ## Features
 
-- Load from multiple data sources(`[]byte`, file and `io.ReadCloser`) with overwrites.
+- Load from multiple data sources(file, `[]byte`, `io.Reader` and `io.ReadCloser`) with overwrites.
 - Read with recursion values.
 - Read with parent-child sections.
 - Read with auto-increment key names.

--- a/file.go
+++ b/file.go
@@ -48,8 +48,8 @@ func newFile(dataSources []dataSource, opts LoadOptions) *File {
 	if len(opts.KeyValueDelimiters) == 0 {
 		opts.KeyValueDelimiters = "=:"
 	}
-	if len(opts.KeyValueDelimitersOutput) == 0 {
-		opts.KeyValueDelimitersOutput = ""
+	if len(opts.KeyValueDelimiterOnWrite) == 0 {
+		opts.KeyValueDelimiterOnWrite = ""
 	}
 	return &File{
 		BlockMode:   true,
@@ -233,10 +233,10 @@ func (f *File) Append(source interface{}, others ...interface{}) error {
 }
 
 func (f *File) writeToBuffer(indent string) (*bytes.Buffer, error) {
-	equalSign := DefaultFormatLeft + f.options.KeyValueDelimitersOutput + DefaultFormatRight
+	equalSign := DefaultFormatLeft + f.options.KeyValueDelimiterOnWrite + DefaultFormatRight
 
 	if PrettyFormat || PrettyEqual {
-		equalSign = fmt.Sprintf(" %s ", f.options.KeyValueDelimitersOutput)
+		equalSign = fmt.Sprintf(" %s ", f.options.KeyValueDelimiterOnWrite)
 	}
 
 	// Use buffer to make sure target is safe until finish encoding.

--- a/file.go
+++ b/file.go
@@ -49,7 +49,7 @@ func newFile(dataSources []dataSource, opts LoadOptions) *File {
 		opts.KeyValueDelimiters = "=:"
 	}
 	if len(opts.KeyValueDelimiterOnWrite) == 0 {
-		opts.KeyValueDelimiterOnWrite = ""
+		opts.KeyValueDelimiterOnWrite = "="
 	}
 	return &File{
 		BlockMode:   true,

--- a/file_test.go
+++ b/file_test.go
@@ -306,6 +306,43 @@ func TestFile_SaveTo(t *testing.T) {
 	})
 }
 
+func TestFile_WriteToWithOutputDelimiter(t *testing.T) {
+	Convey("Write content to somewhere using a custom output delimiter", t, func() {
+		f, err := ini.LoadSources(ini.LoadOptions{
+			KeyValueDelimiterOnWrite: "->",
+		}, []byte(`[Others]
+Cities = HangZhou|Boston
+Visits = 1993-10-07T20:17:05Z, 1993-10-07T20:17:05Z
+Years = 1993,1994
+Numbers = 10010,10086
+Ages = 18,19
+Populations = 12345678,98765432
+Coordinates = 192.168,10.11
+Flags       = true,false
+Note = Hello world!`))
+		So(err, ShouldBeNil)
+		So(f, ShouldNotBeNil)
+
+		var actual bytes.Buffer
+		var expected = []byte(`[Others]
+Cities      -> HangZhou|Boston
+Visits      -> 1993-10-07T20:17:05Z, 1993-10-07T20:17:05Z
+Years       -> 1993,1994
+Numbers     -> 10010,10086
+Ages        -> 18,19
+Populations -> 12345678,98765432
+Coordinates -> 192.168,10.11
+Flags       -> true,false
+Note        -> Hello world!
+
+`)
+		_, err = f.WriteTo(&actual)
+		So(err, ShouldBeNil)
+
+		So(bytes.Equal(expected, actual.Bytes()), ShouldBeTrue)
+	})
+}
+
 // Inspired by https://github.com/go-ini/ini/issues/207
 func TestReloadAfterShadowLoad(t *testing.T) {
 	Convey("Reload file after ShadowLoad", t, func() {

--- a/ini.go
+++ b/ini.go
@@ -104,7 +104,7 @@ type LoadOptions struct {
 	// KeyValueDelimiters is the sequence of delimiters that are used to separate key and value. By default, it is "=:".
 	KeyValueDelimiters string
 	// KeyValueDelimiters is the delimiter that are used to separate key and value output. By default, it is "=".
-	KeyValueDelimitersOutput string
+	KeyValueDelimiterOnWrite string
 	// PreserveSurroundedQuote indicates whether to preserve surrounded quote (single and double quotes).
 	PreserveSurroundedQuote bool
 	// DebugFunc is called to collect debug information (currently only useful to debug parsing Python-style multiline values).


### PR DESCRIPTION
### What problem should be fixed?
See https://github.com/go-ini/ini/pull/203

### Have you added test cases to catch the problem?
I just added a test for the closed PR and also fixed a bug (the default delimiter was set to '' it should be '=')
I also renamed the configuration to KeyValueDelimiterOnWrite as you suggested.