### PR TITLE
file: fix deleting the default section makes the next section inaccessible

### DIFF
--- a/file.go
+++ b/file.go
@@ -347,7 +347,7 @@ func (f *File) writeToBuffer(indent string) (*bytes.Buffer, error) {
 			}
 		}
 
-		if i > 0 || DefaultHeader {
+		if i > 0 || DefaultHeader || (i == 0 && strings.ToUpper(sec.name) != DefaultSection) {
 			if _, err := buf.WriteString("[" + sname + "]" + LineBreak); err != nil {
 				return nil, err
 			}

--- a/file_test.go
+++ b/file_test.go
@@ -332,6 +332,25 @@ func TestFile_DeleteSection(t *testing.T) {
 		f.DeleteSection("")
 		So(f.SectionStrings(), ShouldResemble, []string{"author", "package"})
 	})
+
+	Convey("Delete default section", t, func() {
+		f := ini.Empty()
+		So(f, ShouldNotBeNil)
+
+		f.Section("").Key("foo").SetValue("bar")
+		f.Section("section1").Key("key1").SetValue("value1")
+		f.DeleteSection("")
+		So(f.SectionStrings(), ShouldResemble, []string{"section1"})
+
+		var buf bytes.Buffer
+		_, err := f.WriteTo(&buf)
+		So(err, ShouldBeNil)
+
+		So(buf.String(), ShouldEqual, `[section1]
+key1 = value1
+
+`)
+	})
 }
 
 func TestFile_Append(t *testing.T) {


### PR DESCRIPTION
### What problem should be fixed?
fix  #252
Fix deleting the default section makes the next section inaccessible.

### Have you added test cases to catch the problem?
Yes,here are some test cases.