### PR TITLE
Support Short-circuit load

### DIFF
--- a/file.go
+++ b/file.go
@@ -302,6 +302,9 @@ func (f *File) Reload() (err error) {
 			}
 			return err
 		}
+		if f.options.ShortCircuit {
+			return nil
+		}
 	}
 	return nil
 }

--- a/file_test.go
+++ b/file_test.go
@@ -449,7 +449,7 @@ bar3 = "  val ue3 "
 		var buf bytes.Buffer
 		_, err := f.WriteTo(&buf)
 		So(err, ShouldBeNil)
-		So(buf.String(),ShouldEqual,`[foo]
+		So(buf.String(), ShouldEqual, `[foo]
 bar1 = "  val ue1 "
 bar2 = "  val ue2 "
 bar3 = "  val ue3 "

--- a/ini.go
+++ b/ini.go
@@ -81,6 +81,8 @@ type LoadOptions struct {
 	IgnoreInlineComment bool
 	// SkipUnrecognizableLines indicates whether to skip unrecognizable lines that do not conform to key/value pairs.
 	SkipUnrecognizableLines bool
+	// ShortCircuit indicates whether to ignore other configuration sources after loaded the first available configuration source.
+	ShortCircuit bool
 	// AllowBooleanKeys indicates whether to allow boolean type keys or treat as value is missing.
 	// This type of keys are mostly used in my.cnf.
 	AllowBooleanKeys bool

--- a/ini_test.go
+++ b/ini_test.go
@@ -1368,7 +1368,7 @@ GITHUB = U;n;k;n;w;o;n
 			})
 		})
 
-		Convey("with `ShortCircuit` 'ture'", func() {
+		Convey("ShortCircuit", func() {
 			Convey("Load the first available configuration, ignore other configuration", func() {
 				f, err := ini.LoadSources(ini.LoadOptions{ShortCircuit: true}, minimalConf, []byte(`key1 = value1`))
 				So(f, ShouldNotBeNil)
@@ -1401,7 +1401,7 @@ E-MAIL = u@gogs.io
 `)
 			})
 
-			Convey("Inverse case", func() {
+			Convey("Ensure all sources are loaded without ShortCircuit", func() {
 				f, err := ini.LoadSources(ini.LoadOptions{ShortCircuit: false}, minimalConf, []byte(`key1 = value1`))
 				So(f, ShouldNotBeNil)
 				So(err, ShouldBeNil)

--- a/ini_test.go
+++ b/ini_test.go
@@ -1367,6 +1367,55 @@ GITHUB = U;n;k;n;w;o;n
 				}
 			})
 		})
+
+		Convey("with `ShortCircuit` 'ture'", func() {
+			Convey("Load the first available configuration, ignore other configuration", func() {
+				f, err := ini.LoadSources(ini.LoadOptions{ShortCircuit: true}, minimalConf, []byte(`key1 = value1`))
+				So(f, ShouldNotBeNil)
+				So(err, ShouldBeNil)
+				var buf bytes.Buffer
+				_, err = f.WriteTo(&buf)
+				So(err, ShouldBeNil)
+				So(buf.String(), ShouldEqual, `[author]
+E-MAIL = u@gogs.io
+
+`)
+			})
+
+			Convey("Return an error when fail to load", func() {
+				f, err := ini.LoadSources(ini.LoadOptions{ShortCircuit: true}, notFoundConf, minimalConf)
+				So(f, ShouldBeNil)
+				So(err, ShouldNotBeNil)
+			})
+
+			Convey("Used with Loose to ignore errors that the file does not exist", func() {
+				f, err := ini.LoadSources(ini.LoadOptions{ShortCircuit: true, Loose: true}, notFoundConf, minimalConf)
+				So(f, ShouldNotBeNil)
+				So(err, ShouldBeNil)
+				var buf bytes.Buffer
+				_, err = f.WriteTo(&buf)
+				So(err, ShouldBeNil)
+				So(buf.String(), ShouldEqual, `[author]
+E-MAIL = u@gogs.io
+
+`)
+			})
+
+			Convey("Inverse case", func() {
+				f, err := ini.LoadSources(ini.LoadOptions{ShortCircuit: false}, minimalConf, []byte(`key1 = value1`))
+				So(f, ShouldNotBeNil)
+				So(err, ShouldBeNil)
+				var buf bytes.Buffer
+				_, err = f.WriteTo(&buf)
+				So(err, ShouldBeNil)
+				So(buf.String(), ShouldEqual, `key1 = value1
+
+[author]
+E-MAIL = u@gogs.io
+
+`)
+			})
+		})
 	})
 }
 


### PR DESCRIPTION
### What problem should be fixed?
Short-circuit load #180
1. The ShortCircuit option is adde
2. A judgment is added to the Reload() method to implement short-circuit load.

Note: When ShortCircuit and Loose are both true, ShortCircuit has priority over Loose.
### Have you added test cases to catch the problem?
Yes, all CI pass the test.