### PR TITLE
ci: only upload coverage once per CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,10 +36,11 @@ jobs:
           go mod init gopkg.in/ini.v1
           go test -v -race -coverprofile=coverage -covermode=atomic ./...
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v1.0.6
+        uses: codecov/codecov-action@v1
         with:
           file: ./coverage
           flags: unittests
+        if: matrix.platform == 'ubuntu-latest' && matrix.go-version == '1.15.x'
       - name: Cache downloaded modules
         uses: actions/cache@v1
         with:


### PR DESCRIPTION
### What problem should be fixed?
We have multiple CI environments. It is recommended that one of them be used as the coverage statistics standard.
### Have you added test cases to catch the problem?
No test case is required.