### PR TITLE
Add extends functionality to allow embedded fields

### DIFF
--- a/struct.go
+++ b/struct.go
@@ -312,7 +312,7 @@ func (s *Section) mapToField(val reflect.Value, isStrict bool, sectionIndex int,
 			fieldSection := s
 			if rawName != "" {
 				sectionName = s.name + s.f.options.ChildSectionDelimiter + rawName
-				if secs, err := s.f.SectionsByName(s.name + s.f.options.ChildSectionDelimiter + rawName); err == nil && len(secs) > 0 && sectionIndex < len(secs) {
+				if secs, err := s.f.SectionsByName(sectionName); err == nil && sectionIndex < len(secs) {
 					fieldSection = secs[sectionIndex]
 				}
 			}

--- a/struct_test.go
+++ b/struct_test.go
@@ -387,18 +387,6 @@ names=alice, bruce`))
 	})
 }
 
-func Test_MapToExtended(t *testing.T) {
-	Convey("Map to extended base", t, func() {
-		f, err := ini.Load([]byte(confDataStruct))
-		So(err, ShouldBeNil)
-		So(f, ShouldNotBeNil)
-		te := testExtend{}
-		So(f.Section("extended").MapTo(&te), ShouldBeNil)
-		So(te.Base, ShouldBeTrue)
-		So(te.Extend, ShouldBeTrue)
-	})
-}
-
 func Test_MapToStructNonUniqueSections(t *testing.T) {
 	Convey("Map to struct non unique", t, func() {
 		Convey("Map file to struct non unique", func() {

--- a/struct_test.go
+++ b/struct_test.go
@@ -58,8 +58,8 @@ type testStruct struct {
 	Unused         int `ini:"-"`
 	Unsigned       uint
 	Omitted        bool     `ini:"omitthis,omitempty"`
-	Shadows        []string `ini:",,allowshadow"`
-	ShadowInts     []int    `ini:"Shadows,,allowshadow"`
+	Shadows        []string `ini:",allowshadow"`
+	ShadowInts     []int    `ini:"Shadows,allowshadow"`
 	BoolPtr        *bool
 	BoolPtrNil     *bool
 	FloatPtr       *float64
@@ -90,7 +90,7 @@ type testPeer struct {
 
 type testNonUniqueSectionsStruct struct {
 	Interface testInterface
-	Peer      []testPeer `ini:",,,nonunique"`
+	Peer      []testPeer `ini:",nonunique"`
 }
 
 type BaseStruct struct {
@@ -98,7 +98,7 @@ type BaseStruct struct {
 }
 
 type testExtend struct {
-	BaseStruct `ini:",,,,extends"`
+	BaseStruct `ini:",extends"`
 	Extend     bool
 }
 
@@ -478,7 +478,7 @@ FieldInSection = 6
 			}
 
 			type File struct {
-				Sections []Section `ini:"Section,,,nonunique"`
+				Sections []Section `ini:"Section,nonunique"`
 			}
 
 			f := new(File)
@@ -770,18 +770,18 @@ path = /tmp/gpm-profiles/test1.profile
 				AllowShadows: true,
 			})
 			type ShadowStruct struct {
-				StringArray      []string    `ini:"sa,,allowshadow"`
+				StringArray      []string    `ini:"sa,allowshadow"`
 				EmptyStringArrat []string    `ini:"empty,omitempty,allowshadow"`
-				Allowshadow      []string    `ini:"allowshadow,,allowshadow"`
-				Dates            []time.Time `ini:",,allowshadow"`
-				Places           []string    `ini:",,allowshadow"`
-				Years            []int       `ini:",,allowshadow"`
-				Numbers          []int64     `ini:",,allowshadow"`
-				Ages             []uint      `ini:",,allowshadow"`
-				Populations      []uint64    `ini:",,allowshadow"`
-				Coordinates      []float64   `ini:",,allowshadow"`
-				Flags            []bool      `ini:",,allowshadow"`
-				None             []int       `ini:",,allowshadow"`
+				Allowshadow      []string    `ini:"allowshadow,allowshadow"`
+				Dates            []time.Time `ini:",allowshadow"`
+				Places           []string    `ini:",allowshadow"`
+				Years            []int       `ini:",allowshadow"`
+				Numbers          []int64     `ini:",allowshadow"`
+				Ages             []uint      `ini:",allowshadow"`
+				Populations      []uint64    `ini:",allowshadow"`
+				Coordinates      []float64   `ini:",allowshadow"`
+				Flags            []bool      `ini:",allowshadow"`
+				None             []int       `ini:",allowshadow"`
 			}
 
 			shadow := &ShadowStruct{

--- a/struct_test.go
+++ b/struct_test.go
@@ -93,6 +93,15 @@ type testNonUniqueSectionsStruct struct {
 	Peer      []testPeer `ini:",,,nonunique"`
 }
 
+type BaseStruct struct {
+	Base bool
+}
+
+type testExtend struct {
+	BaseStruct `ini:",,,,extends"`
+	Extend     bool
+}
+
 const confDataStruct = `
 NAME = Unknwon
 Age = 21
@@ -141,6 +150,10 @@ GPA = 2.8
 [foo.bar]
 Here = there
 When = then
+
+[extended]
+Base = true
+Extend = true
 `
 
 const confNonUniqueSectionDataStruct = `[Interface]
@@ -332,6 +345,16 @@ func Test_MapToStruct(t *testing.T) {
 			So(dv.Born.String(), ShouldEqual, t.String())
 			So(strings.Join(dv.Cities, ","), ShouldEqual, "HangZhou,Boston")
 		})
+
+		Convey("Map to extended base", func() {
+			f, err := ini.Load([]byte(confDataStruct))
+			So(err, ShouldBeNil)
+			So(f, ShouldNotBeNil)
+			te := testExtend{}
+			So(f.Section("extended").MapTo(&te), ShouldBeNil)
+			So(te.Base, ShouldBeTrue)
+			So(te.Extend, ShouldBeTrue)
+		})
 	})
 
 	Convey("Map to struct in strict mode", t, func() {
@@ -361,6 +384,18 @@ names=alice, bruce`))
 
 		So(f.Section("").StrictMapTo(s), ShouldBeNil)
 		So(fmt.Sprint(s.Names), ShouldEqual, "[alice bruce]")
+	})
+}
+
+func Test_MapToExtended(t *testing.T) {
+	Convey("Map to extended base", t, func() {
+		f, err := ini.Load([]byte(confDataStruct))
+		So(err, ShouldBeNil)
+		So(f, ShouldNotBeNil)
+		te := testExtend{}
+		So(f.Section("extended").MapTo(&te), ShouldBeNil)
+		So(te.Base, ShouldBeTrue)
+		So(te.Extend, ShouldBeTrue)
 	})
 }
 


### PR DESCRIPTION
### What problem should be fixed?

Allow embedded structs to inherit from the same ini section.

```go
type Base struct {
  Inherited bool
}

type Extended struct {
  Base `ini:",,,,extends"`
  Extended bool
}
```

```ini
[section]
Inherited=true
Extended=true
```

### Have you added test cases to catch the problem?

Yes

Signed-off-by: Andrew Thornton <art27@cantab.net>
