### PR TITLE
Making DefaultSection modifyable to handle aws profile default.

### DIFF
--- a/deprecated.go
+++ b/deprecated.go
@@ -14,12 +14,10 @@
 
 package ini
 
-const (
-	// Deprecated: Use "DefaultSection" instead.
-	DEFAULT_SECTION = DefaultSection
-)
-
 var (
 	// Deprecated: AllCapsUnderscore converts to format ALL_CAPS_UNDERSCORE.
 	AllCapsUnderscore = SnackCase
+
+	// Deprecated: Use "DefaultSection" instead.
+	DEFAULT_SECTION = DefaultSection
 )

--- a/ini.go
+++ b/ini.go
@@ -25,15 +25,15 @@ import (
 )
 
 const (
-	// DefaultSection is the name of default section. You can use this constant or the string literal.
-	// In most of cases, an empty string is all you need to access the section.
-	DefaultSection = "DEFAULT"
-
 	// Maximum allowed depth when recursively substituing variable names.
 	depthValues = 99
 )
 
 var (
+	// DefaultSection is the name of default section. You can use this var or the string literal.
+	// In most of cases, an empty string is all you need to access the section.
+	DefaultSection = "DEFAULT"
+
 	// LineBreak is the delimiter to determine or compose a new line.
 	// This variable will be changed to "\r\n" automatically on Windows at package init time.
 	LineBreak = "\n"


### PR DESCRIPTION
This was done to fix the handling of aws credential files. If the default section is not modifyable then when the profiles are loaded from the credentials file, an erronious non-existent DEFAULT section is returned as part of the results array. When given the ability to modify DefaultSection and set it to lower case 'default', it loads the credentials as would be expected.