### PR TITLE
key: add `AllowDuplicateShadowValues` option

### DIFF
--- a/ini.go
+++ b/ini.go
@@ -125,6 +125,8 @@ type LoadOptions struct {
 	ReaderBufferSize int
 	// AllowNonUniqueSections indicates whether to allow sections with the same name multiple times.
 	AllowNonUniqueSections bool
+	// AllowDuplicateShadowValues indicates whether values for shadowed keys should be deduplicated.
+	AllowDuplicateShadowValues bool
 }
 
 // DebugFunc is the type of function called to log parse events.

--- a/key.go
+++ b/key.go
@@ -54,13 +54,15 @@ func (k *Key) addShadow(val string) error {
 		return errors.New("cannot add shadow to auto-increment or boolean key")
 	}
 
-	// Deduplicate shadows based on their values.
-	if k.value == val {
-		return nil
-	}
-	for i := range k.shadows {
-		if k.shadows[i].value == val {
+	if !k.s.f.options.AllowDuplicateShadowValues {
+		// Deduplicate shadows based on their values.
+		if k.value == val {
 			return nil
+		}
+		for i := range k.shadows {
+			if k.shadows[i].value == val {
+				return nil
+			}
 		}
 	}
 
@@ -781,9 +783,7 @@ func (k *Key) parseUint64s(strs []string, addInvalid, returnOnInvalid bool) ([]u
 	return vals, err
 }
 
-
 type Parser func(str string) (interface{}, error)
-
 
 // parseTimesFormat transforms strings to times in given format.
 func (k *Key) parseTimesFormat(format string, strs []string, addInvalid, returnOnInvalid bool) ([]time.Time, error) {
@@ -800,7 +800,6 @@ func (k *Key) parseTimesFormat(format string, strs []string, addInvalid, returnO
 	}
 	return vals, err
 }
-
 
 // doParse transforms strings to different types
 func (k *Key) doParse(strs []string, addInvalid, returnOnInvalid bool, parser Parser) ([]interface{}, error) {

--- a/key_test.go
+++ b/key_test.go
@@ -51,6 +51,29 @@ func TestKey_AddShadow(t *testing.T) {
 		Convey("Add shadow to auto-increment key", func() {
 			So(f.Section("notes").Key("#1").AddShadow("beta"), ShouldNotBeNil)
 		})
+
+		Convey("Deduplicate an existing value", func() {
+			k := f.Section("").Key("NAME")
+			So(k.AddShadow("ini"), ShouldBeNil)
+			So(k.ValueWithShadows(), ShouldResemble, []string{"ini", "ini.v1"})
+		})
+	})
+
+	Convey("Allow duplicate shadowed values", t, func() {
+		f := ini.Empty(ini.LoadOptions{
+			AllowShadows:               true,
+			AllowDuplicateShadowValues: true,
+		})
+		So(f, ShouldNotBeNil)
+
+		k, err := f.Section("").NewKey("NAME", "ini")
+		So(err, ShouldBeNil)
+		So(k, ShouldNotBeNil)
+
+		So(k.AddShadow("ini.v1"), ShouldBeNil)
+		So(k.AddShadow("ini"), ShouldBeNil)
+		So(k.AddShadow("ini"), ShouldBeNil)
+		So(k.ValueWithShadows(), ShouldResemble, []string{"ini", "ini.v1", "ini", "ini"})
 	})
 
 	Convey("Shadow is not allowed", t, func() {


### PR DESCRIPTION
Copied from #285 since I don't seem to be able to change the target of that one.

### What problem should be fixed?

Fixes #284.

### Have you added test cases to catch the problem?

Test cases have been added to key_test.go for both the default and new cases.