### PR TITLE
Fix nested values can span sections

### DIFF
--- a/ini_test.go
+++ b/ini_test.go
@@ -1562,3 +1562,75 @@ Eu feugiat pretium nibh ipsum consequat nisl vel pretium lectus. Habitant morbi 
 		testData.Value3,
 	)
 }
+
+func Test_NestedValuesSpanningSections(t *testing.T) {
+	t.Run("basic nested value", func(t *testing.T) {
+		f, err := LoadSources(LoadOptions{
+			AllowNestedValues: true,
+		}, []byte(`
+[section]
+key1 = value1
+key2 =
+  nested1 = nestedvalue1
+`))
+		require.NoError(t, err)
+		require.NotNil(t, f)
+
+		assert.Equal(t, "value1", f.Section("section").Key("key1").String())
+		assert.Equal(t, "", f.Section("section").Key("key2").String())
+		assert.Equal(t, []string{"nested1 = nestedvalue1"}, f.Section("section").Key("key2").NestedValues())
+	})
+
+	t.Run("no nested values", func(t *testing.T) {
+		f, err := LoadSources(LoadOptions{
+			AllowNestedValues: true,
+		}, []byte(`
+[section]
+key1 = value1
+key2 =
+`))
+		require.NoError(t, err)
+		require.NotNil(t, f)
+
+		assert.Equal(t, "value1", f.Section("section").Key("key1").String())
+		assert.Equal(t, "", f.Section("section").Key("key2").String())
+	})
+
+	t.Run("no nested values and following sections", func(t *testing.T) {
+		f, err := LoadSources(LoadOptions{
+			AllowNestedValues: true,
+		}, []byte(`
+[section]
+key1 = value1
+key2 =
+
+[section2]
+key3 = value3
+`))
+		require.NoError(t, err)
+		require.NotNil(t, f)
+
+		assert.Equal(t, "value1", f.Section("section").Key("key1").String())
+		assert.Equal(t, "", f.Section("section").Key("key2").String())
+		assert.Equal(t, "value3", f.Section("section2").Key("key3").String())
+	})
+
+	t.Run("no nested values and following sections with indentation", func(t *testing.T) {
+		f, err := LoadSources(LoadOptions{
+			AllowNestedValues: true,
+		}, []byte(`
+[section]
+key1 = value1
+key2 =
+
+[section2]
+  key3 = value3
+`))
+		require.NoError(t, err)
+		require.NotNil(t, f)
+
+		assert.Equal(t, "value1", f.Section("section").Key("key1").String())
+		assert.Equal(t, "", f.Section("section").Key("key2").String())
+		assert.Equal(t, "value3", f.Section("section2").Key("key3").String())
+	})
+}

--- a/parser.go
+++ b/parser.go
@@ -461,6 +461,8 @@ func (f *File) parse(reader io.Reader) (err error) {
 			// Reset auto-counter and comments
 			p.comment.Reset()
 			p.count = 1
+			// Nested values can't span sections
+			isLastValueEmpty = false
 
 			inUnparseableSection = false
 			for i := range f.options.UnparseableSections {


### PR DESCRIPTION
### What problem should be fixed?
When configured with `AllowNestedValues: true`, the parser attempts to parse values "nested" under a key, [AWS-style](https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#nested-values). To trigger this behavior, the parent key must have an empty value, and child keys must be indented. However, if the next value is in a different section, it cannot be a nested value, but the parser can treat it as such anyways. As an example:

```
[section]
key1 = value1
key2 =
[section2]
  key3 = value3
```

Before this PR, `key3` is treated as a nested value under `key2`, and `section2` has no keys. 

### Have you added test cases to catch the problem?

Yes, I've added tests that cover the issue and fail on the current tip of `main`.