### PR TITLE
Fix python multiline EOF error

### DIFF
--- a/ini_test.go
+++ b/ini_test.go
@@ -1562,3 +1562,26 @@ func TestPythonMultiline(t *testing.T) {
 		testData.Value3,
 	)
 }
+
+func TestPythonMultiline_EOF(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping testing on Windows")
+	}
+
+	path := filepath.Join("testdata", "multiline_eof.ini")
+	f, err := LoadSources(LoadOptions{
+		AllowPythonMultilineValues: true,
+		ReaderBufferSize:           64 * 1024,
+	}, path)
+	require.NoError(t, err)
+	require.NotNil(t, f)
+	assert.Len(t, f.Sections(), 1)
+
+	defaultSection := f.Section("")
+	assert.NotNil(t, f.Section(""))
+
+	var testData testData
+	err = defaultSection.MapTo(&testData)
+	require.NoError(t, err)
+	assert.Equal(t, "some text here\n\tsome more text here 2", testData.Value1)
+}

--- a/parser.go
+++ b/parser.go
@@ -304,12 +304,7 @@ func (p *parser) readPythonMultilines(line string, bufferSize int) (string, erro
 
 	for {
 		peekData, peekErr := peekBuffer.ReadBytes('\n')
-		if peekErr != nil {
-			if peekErr == io.EOF {
-				p.debug("readPythonMultilines: io.EOF, peekData: %q, line: %q", string(peekData), line)
-				return line, nil
-			}
-
+		if peekErr != nil && peekErr != io.EOF {
 			p.debug("readPythonMultilines: failed to peek with error: %v", peekErr)
 			return "", peekErr
 		}

--- a/testdata/multiline_eof.ini
+++ b/testdata/multiline_eof.ini
@@ -1,0 +1,2 @@
+value1 = some text here
+	some more text here 2


### PR DESCRIPTION
### What problem should be fixed?

When parsing `python multiline` values and the key which is being parsed is the last one on the ini file and there's no new line at the end, then it throws an error. To fix that we might not consider EOF as an error when reading the last line because it's either can be a `\n` or `EOF`.

This problem was first reported [here](https://github.com/wakatime/wakatime-cli/issues/593).

### Have you added test cases to catch the problem?

The `TestPythonMultiline_EOF` was added.