### PR TITLE
Return an empty array from `ValueWithShadows` if there is none

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*_test.go]
+trim_trailing_whitespace = false

--- a/file.go
+++ b/file.go
@@ -442,30 +442,16 @@ func (f *File) writeToBuffer(indent string) (*bytes.Buffer, error) {
 				kname = `"""` + kname + `"""`
 			}
 
-			shadows := key.ValueWithShadows()
-			if len(shadows) == 0 {
+			writeKeyValue := func(val string) (bool, error) {
 				if _, err := buf.WriteString(kname); err != nil {
-					return nil, err
-				}
-				// Write out alignment spaces before "=" sign
-				if PrettyFormat {
-					buf.Write(alignSpaces[:alignLength-len(kname)])
-				}
-				if _, err := buf.WriteString(equalSign + LineBreak); err != nil {
-					return nil, err
-				}
-			}
-
-			for _, val := range shadows {
-				if _, err := buf.WriteString(kname); err != nil {
-					return nil, err
+					return false, err
 				}
 
 				if key.isBooleanType {
 					if kname != sec.keyList[len(sec.keyList)-1] {
 						buf.WriteString(LineBreak)
 					}
-					continue KeyList
+					return true, nil
 				}
 
 				// Write out alignment spaces before "=" sign
@@ -482,7 +468,24 @@ func (f *File) writeToBuffer(indent string) (*bytes.Buffer, error) {
 					val = `"` + val + `"`
 				}
 				if _, err := buf.WriteString(equalSign + val + LineBreak); err != nil {
+					return false, err
+				}
+				return false, nil
+			}
+
+			shadows := key.ValueWithShadows()
+			if len(shadows) == 0 {
+				if _, err := writeKeyValue(""); err != nil {
 					return nil, err
+				}
+			}
+
+			for _, val := range shadows {
+				exit_loop, err := writeKeyValue(val)
+				if err != nil {
+					return nil, err
+				} else if exit_loop {
+					continue KeyList
 				}
 			}
 

--- a/file.go
+++ b/file.go
@@ -481,10 +481,10 @@ func (f *File) writeToBuffer(indent string) (*bytes.Buffer, error) {
 			}
 
 			for _, val := range shadows {
-				exit_loop, err := writeKeyValue(val)
+				exitLoop, err := writeKeyValue(val)
 				if err != nil {
 					return nil, err
-				} else if exit_loop {
+				} else if exitLoop {
 					continue KeyList
 				}
 			}

--- a/file.go
+++ b/file.go
@@ -442,7 +442,21 @@ func (f *File) writeToBuffer(indent string) (*bytes.Buffer, error) {
 				kname = `"""` + kname + `"""`
 			}
 
-			for _, val := range key.ValueWithShadows() {
+			shadows := key.ValueWithShadows()
+			if len(shadows) == 0 {
+				if _, err := buf.WriteString(kname); err != nil {
+					return nil, err
+				}
+				// Write out alignment spaces before "=" sign
+				if PrettyFormat {
+					buf.Write(alignSpaces[:alignLength-len(kname)])
+				}
+				if _, err := buf.WriteString(equalSign + LineBreak); err != nil {
+					return nil, err
+				}
+			}
+
+			for _, val := range shadows {
 				if _, err := buf.WriteString(kname); err != nil {
 					return nil, err
 				}

--- a/key.go
+++ b/key.go
@@ -113,6 +113,9 @@ func (k *Key) Value() string {
 // ValueWithShadows returns raw values of key and its shadows if any.
 func (k *Key) ValueWithShadows() []string {
 	if len(k.shadows) == 0 {
+		if k.value == "" {
+			return []string{}
+		}
 		return []string{k.value}
 	}
 	vals := make([]string, len(k.shadows)+1)

--- a/key.go
+++ b/key.go
@@ -112,10 +112,10 @@ func (k *Key) Value() string {
 
 // ValueWithShadows returns raw values of key and its shadows if any.
 func (k *Key) ValueWithShadows() []string {
-	if !k.s.HasKey(k.name) {
-		return []string{}
-	}
 	if len(k.shadows) == 0 {
+		if k.value == "" {
+			return []string{}
+		}
 		return []string{k.value}
 	}
 	vals := make([]string, len(k.shadows)+1)

--- a/key.go
+++ b/key.go
@@ -112,10 +112,10 @@ func (k *Key) Value() string {
 
 // ValueWithShadows returns raw values of key and its shadows if any.
 func (k *Key) ValueWithShadows() []string {
+	if !k.s.HasKey(k.name) {
+		return []string{}
+	}
 	if len(k.shadows) == 0 {
-		if k.value == "" {
-			return []string{}
-		}
 		return []string{k.value}
 	}
 	vals := make([]string, len(k.shadows)+1)

--- a/key_test.go
+++ b/key_test.go
@@ -521,6 +521,25 @@ func TestKey_Helpers(t *testing.T) {
 	})
 }
 
+func testKey_ValueWithShadows(t *testing.T) {
+	t.Run("", func(t *testing.T) {
+		f, err := ShadowLoad([]byte(`
+keyName = value1
+keyName = value2
+`))
+		require.NoError(t, err)
+		require.NotNil(t, f)
+
+		k := f.Section("").Key("FakeKey")
+		require.NotNil(t, k)
+		assert.Equal(t, []string{}, k.ValueWithShadows())
+
+		k = f.Section("").Key("keyName")
+		require.NotNil(t, k)
+		assert.Equal(t, []string{"value1", "value2"}, k.ValueWithShadows())
+	})
+}
+
 func TestKey_StringsWithShadows(t *testing.T) {
 	t.Run("get strings of shadows of a key", func(t *testing.T) {
 		f, err := ShadowLoad([]byte(""))

--- a/key_test.go
+++ b/key_test.go
@@ -521,7 +521,7 @@ func TestKey_Helpers(t *testing.T) {
 	})
 }
 
-func testKey_ValueWithShadows(t *testing.T) {
+func TestKey_ValueWithShadows(t *testing.T) {
 	t.Run("", func(t *testing.T) {
 		f, err := ShadowLoad([]byte(`
 keyName = value1


### PR DESCRIPTION

When there are no value for a given key, ValueWithShadows used to return an array containing an empty string. Instead, this PR makes it return an empty array. This change produces the same behaviour for StringsWithShadows as it uses ValueWithShadows to do it's job.

Link to the issue: https://github.com/go-ini/ini/issues/310

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/go-ini/ini/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.
There aren't any existing test cases for ValueWithShadows. Should I add a new one ?


PS: I tried to wait a little before doing the PR in case any newcomer wanted to use the opportunity of this simple fix for their first PR, but it's been a month now so I'll  just do it myself ¯\\\_(ツ)_/¯