### PR TITLE
key: ignore empty values in `ValueWithShadows`

### DIFF
--- a/key.go
+++ b/key.go
@@ -110,7 +110,8 @@ func (k *Key) Value() string {
 	return k.value
 }
 
-// ValueWithShadows returns raw values of key and its shadows if any.
+// ValueWithShadows returns raw values of key and its shadows if any. Shadow
+// keys with empty values are ignored from the returned list.
 func (k *Key) ValueWithShadows() []string {
 	if len(k.shadows) == 0 {
 		if k.value == "" {
@@ -118,10 +119,15 @@ func (k *Key) ValueWithShadows() []string {
 		}
 		return []string{k.value}
 	}
-	vals := make([]string, len(k.shadows)+1)
-	vals[0] = k.value
-	for i := range k.shadows {
-		vals[i+1] = k.shadows[i].value
+
+	vals := make([]string, 0, len(k.shadows)+1)
+	if k.value != "" {
+		vals = append(vals, k.value)
+	}
+	for _, s := range k.shadows {
+		if s.value != "" {
+			vals = append(vals, s.value)
+		}
 	}
 	return vals
 }

--- a/key_test.go
+++ b/key_test.go
@@ -57,6 +57,13 @@ func TestKey_AddShadow(t *testing.T) {
 			assert.NoError(t, k.AddShadow("ini"))
 			assert.Equal(t, []string{"ini", "ini.v1"}, k.ValueWithShadows())
 		})
+
+		t.Run("ignore empty shadow values", func(t *testing.T) {
+			k := f.Section("").Key("empty")
+			assert.NoError(t, k.AddShadow(""))
+			assert.NoError(t, k.AddShadow("ini"))
+			assert.Equal(t, []string{"ini"}, k.ValueWithShadows())
+		})
 	})
 
 	t.Run("allow duplicate shadowed values", func(t *testing.T) {


### PR DESCRIPTION
### Describe the pull request

Empty values of shadow keys are ignored in the returned list of `ValueWithShadows`.

Link to the issue: https://github.com/go-ini/ini/issues/294

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/go-ini/ini/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.
