### PR TITLE
ini: allow changing the default section name

### DIFF
--- a/deprecated.go
+++ b/deprecated.go
@@ -14,12 +14,9 @@
 
 package ini
 
-const (
+var (
 	// Deprecated: Use "DefaultSection" instead.
 	DEFAULT_SECTION = DefaultSection
-)
-
-var (
 	// Deprecated: AllCapsUnderscore converts to format ALL_CAPS_UNDERSCORE.
 	AllCapsUnderscore = SnackCase
 )

--- a/ini.go
+++ b/ini.go
@@ -23,15 +23,15 @@ import (
 )
 
 const (
-	// DefaultSection is the name of default section. You can use this constant or the string literal.
-	// In most of cases, an empty string is all you need to access the section.
-	DefaultSection = "DEFAULT"
-
 	// Maximum allowed depth when recursively substituing variable names.
 	depthValues = 99
 )
 
 var (
+	// DefaultSection is the name of default section. You can use this var or the string literal.
+	// In most of cases, an empty string is all you need to access the section.
+	DefaultSection = "DEFAULT"
+
 	// LineBreak is the delimiter to determine or compose a new line.
 	// This variable will be changed to "\r\n" automatically on Windows at package init time.
 	LineBreak = "\n"


### PR DESCRIPTION
### Describe the pull request

Changed the DefaultSection constant to a variable so that it may be altered for use with AWS cli configs.

Link to the issue: https://github.com/go-ini/ini/issues/287

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/go-ini/ini/blob/main/.github/contributing.md).
- [ ] I have added test cases to cover the new code.
