### PR TITLE
parser: fix line skipping when key is empty

### DIFF
--- a/error.go
+++ b/error.go
@@ -32,3 +32,18 @@ func IsErrDelimiterNotFound(err error) bool {
 func (err ErrDelimiterNotFound) Error() string {
 	return fmt.Sprintf("key-value delimiter not found: %s", err.Line)
 }
+
+// ErrEmptyKeyName indicates the error type of no key name is found which there should be one.
+type ErrEmptyKeyName struct {
+	Line string
+}
+
+// IsErrEmptyKeyName returns true if the given error is an instance of ErrEmptyKeyName.
+func IsErrEmptyKeyName(err error) bool {
+	_, ok := err.(ErrEmptyKeyName)
+	return ok
+}
+
+func (err ErrEmptyKeyName) Error() string {
+	return fmt.Sprintf("empty key name: %s", err.Line)
+}

--- a/ini_test.go
+++ b/ini_test.go
@@ -445,6 +445,8 @@ BiomeRarityScale: 100
 
 BiomeGroup(NormalBiomes, 3, 99, RoofedForestEnchanted, ForestSakura, FloatingJungle
 BiomeGroup(IceBiomes, 4, 85, Ice Plains)
+
+= RainForest
 `))
 			require.NoError(t, err)
 			require.NotNil(t, f)

--- a/parser.go
+++ b/parser.go
@@ -161,7 +161,7 @@ func readKeyName(delimiters string, in []byte) (string, int, error) {
 	}
 
 	endIdx = strings.IndexAny(line, delimiters)
-	if endIdx < 0 {
+	if endIdx <= 0 {
 		return "", -1, ErrDelimiterNotFound{line}
 	}
 	return strings.TrimSpace(line[0:endIdx]), endIdx + 1, nil


### PR DESCRIPTION
### Describe the pull request

This PR fixes a scenario where the key name is zero length and `readKeyName` incorrectly handle it. Even if setting `SkipUnrecognizableLines` to **true** wasn't being skipped. 

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/go-ini/ini/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code.
