### PR TITLE
Fix value format when SpaceBeforeInlineComment:true

### DIFF
--- a/file_test.go
+++ b/file_test.go
@@ -457,6 +457,50 @@ test   =
 
 	})
 
+	t.Run("support inline comments (no require space before)", func(t *testing.T) {
+		f, err := LoadSources(LoadOptions{SpaceBeforeInlineComment: false}, []byte{})
+		require.NoError(t, err)
+		var buf bytes.Buffer
+
+		f.Section("").Key("test").SetValue("a#b")
+		_, err = f.WriteTo(&buf)
+		require.NoError(t, err)
+		assert.Equal(t, "test = `a#b`\n", buf.String())
+	})
+
+	t.Run("support inline comments (no require space before)", func(t *testing.T) {
+		f, err := LoadSources(LoadOptions{SpaceBeforeInlineComment: false}, []byte{})
+		require.NoError(t, err)
+		var buf bytes.Buffer
+
+		f.Section("").Key("test").SetValue("a #b")
+		_, err = f.WriteTo(&buf)
+		require.NoError(t, err)
+		assert.Equal(t, "test = `a #b`\n", buf.String())
+	})
+
+	t.Run("support inline comments (require space before)", func(t *testing.T) {
+		f, err := LoadSources(LoadOptions{SpaceBeforeInlineComment: true}, []byte{})
+		require.NoError(t, err)
+		var buf bytes.Buffer
+
+		f.Section("").Key("test").SetValue("a#b")
+		_, err = f.WriteTo(&buf)
+		require.NoError(t, err)
+		assert.Equal(t, "test = a#b\n", buf.String())
+	})
+
+	t.Run("support inline comments (require space before)", func(t *testing.T) {
+		f, err := LoadSources(LoadOptions{SpaceBeforeInlineComment: true}, []byte{})
+		require.NoError(t, err)
+		var buf bytes.Buffer
+
+		f.Section("").Key("test").SetValue("a #b")
+		_, err = f.WriteTo(&buf)
+		require.NoError(t, err)
+		assert.Equal(t, "test = `a #b`\n", buf.String())
+	})
+
 	t.Run("keep leading and trailing spaces in value", func(t *testing.T) {
 		f, _ := Load([]byte(`[foo]
 bar1 = '  val ue1 '


### PR DESCRIPTION
Hello,

Would you be interested in that patch ?

Setting the a#b value when SpaceBeforeInlineComment is true should not
quote the value.

Thank you for your work.