### PR TITLE
add NoMultiLineSurroundingQuotes option

### DIFF
--- a/file.go
+++ b/file.go
@@ -460,7 +460,7 @@ func (f *File) writeToBuffer(indent string) (*bytes.Buffer, error) {
 				}
 
 				// In case key value contains "\n", "`", "\"", "#" or ";"
-				if strings.ContainsAny(val, "\n`") {
+				if !f.options.NoMultiLineSurroundingQuotes && strings.ContainsAny(val, "\n`") {
 					val = `"""` + val + `"""`
 				} else if !f.options.IgnoreInlineComment && strings.ContainsAny(val, "#;") {
 					val = "`" + val + "`"

--- a/ini.go
+++ b/ini.go
@@ -115,6 +115,8 @@ type LoadOptions struct {
 	KeyValueDelimiterOnWrite string
 	// ChildSectionDelimiter is the delimiter that is used to separate child sections. By default, it is ".".
 	ChildSectionDelimiter string
+	// NoMultiLineSurroundingQuotes indicates whether to add surrounding triple quotes to multi-line values.
+	NoMultiLineSurroundingQuotes bool
 	// PreserveSurroundedQuote indicates whether to preserve surrounded quote (single and double quotes).
 	PreserveSurroundedQuote bool
 	// DebugFunc is called to collect debug information (currently only useful to debug parsing Python-style multiline values).


### PR DESCRIPTION
### Describe the pull request

Consider the following multi-line ini file:
```ini
value1 = some text here
	some more text here 2
```

Run the following code:
```go
path := "multiline_eof.ini"
f, _ := ini.LoadSources(ini.LoadOptions{
  AllowPythonMultilineValues: true,
}, path)

f.Section("").Key("value1").SetValue("some text here\n\tsome more text here 2")
f.SaveTo(path)
```

Will output:
```ini
value1 = """some text here
	some more text here 2"""
```

Now run:
```go
path := "multiline_eof.ini"
f, _ := ini.LoadSources(ini.LoadOptions{
  AllowPythonMultilineValues: true,
  NoMultiLineSurroundingQuotes: true,
}, path)

f.Section("").Key("value1").SetValue("some text here\n\tsome more text here 2")
f.SaveTo(path)
```

The output is the same as the original file
```ini
value1 = some text here
	some more text here 2
```

Link to the issue: n/a

### Checklist

- [*] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [*] I have read and acknowledge the [Contributing guide](https://github.com/go-ini/ini/blob/main/.github/contributing.md).
- [*] I have added test cases to cover the new code.
