### PR TITLE
Fix error message for missing key

### DIFF
--- a/section.go
+++ b/section.go
@@ -131,7 +131,7 @@ func (s *Section) GetKey(name string) (*Key, error) {
 			}
 			break
 		}
-		return nil, fmt.Errorf("error when getting key of section %q: key %q not exists", s.name, name)
+		return nil, fmt.Errorf("error when getting key of section %q: key %q does not exist", s.name, name)
 	}
 	return key, nil
 }


### PR DESCRIPTION
This fixes the grammar in the error message for a missing key: "key %q not exists" to "key %q does not exist"

Link to the issue: n/a

### Checklist

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledge the [Contributing guide](https://github.com/go-ini/ini/blob/main/.github/contributing.md).
- [ ] I have added test cases to cover the new code.

I didn't add new test cases, but the behaviour is unchanged and tested here already:

https://github.com/go-ini/ini/blob/b2f570e5b5b844226bbefe6fb521d891f529a951/section_test.go#L126-L129

This test is independent of the error message itself.