### PR TITLE
Apply insensitive key name when deleting a key

### DIFF
--- a/section.go
+++ b/section.go
@@ -226,6 +226,10 @@ func (s *Section) KeysHash() map[string]string {
 
 // DeleteKey deletes a key from section.
 func (s *Section) DeleteKey(name string) {
+	if s.f.options.Insensitive || s.f.options.InsensitiveKeys {
+		name = strings.ToLower(name)
+	}
+
 	if s.f.BlockMode {
 		s.f.lock.Lock()
 		defer s.f.lock.Unlock()

--- a/section_test.go
+++ b/section_test.go
@@ -312,4 +312,14 @@ func TestSection_DeleteKey(t *testing.T) {
 		f.Section("").DeleteKey("NAME")
 		assert.False(t, f.Section("").HasKey("NAME"))
 	})
+
+	t.Run("delete a key with insensitive names", func(t *testing.T) {
+		f, err := LoadSources(LoadOptions{Insensitive: true}, []byte("TestKey = value"))
+		require.NoError(t, err)
+		require.NotNil(t, f)
+
+		assert.True(t, f.Section("").HasKey("TestKey"))
+		f.Section("").DeleteKey("TestKey")
+		assert.False(t, f.Section("").HasKey("TestKey"))
+	})
 }


### PR DESCRIPTION
Fixes #340.

`Section.DeleteKey` did not honour `Insensitive`/`InsensitiveKeys`, so a key loaded case-insensitively could not be deleted by a differently-cased name and `DeleteKey` became a no-op. Lower-case the name the same way the rest of the section does before matching. Added a test that deletes a key under `Insensitive: true`.